### PR TITLE
Add products CRUD and marketing storefront updates

### DIFF
--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -1,56 +1,68 @@
 import { CreateUserForm } from "@/components/auth/create-user-form";
+import { ProductManager } from "@/components/products/product-manager";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { listProducts } from "@/lib/products";
 import { listUsers } from "@/lib/users";
 
 export default async function AdminPage() {
   const users = await listUsers();
+  const products = await listProducts();
 
   return (
-    <section className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-semibold">Admin overview</h1>
+    <section className="space-y-12">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">Admin overview</h1>
         <p className="text-muted-foreground">
-          Review all registered users. Only admins and super admins can access this area.
+          Review user accounts and curate the catalogue that powers the storefront experience.
         </p>
       </div>
-      <CreateUserForm
-        allowedRoles={["user"]}
-        heading="Invite a new user"
-        description="Create shopper or staff accounts. They can update their password after first sign in."
-      />
-      <Card>
-        <CardHeader>
-          <CardTitle>Users</CardTitle>
-        </CardHeader>
-        <CardContent className="overflow-x-auto">
-          <table className="min-w-full text-left text-sm">
-            <thead className="border-b bg-muted/40 text-muted-foreground">
-              <tr>
-                <th className="px-4 py-2">Name</th>
-                <th className="px-4 py-2">Email</th>
-                <th className="px-4 py-2">Role</th>
-                <th className="px-4 py-2">Joined</th>
-              </tr>
-            </thead>
-            <tbody>
-              {users.map((user) => (
-                <tr key={user.id} className="border-b last:border-0">
-                  <td className="px-4 py-2 font-medium">{user.name}</td>
-                  <td className="px-4 py-2 text-muted-foreground">{user.email}</td>
-                  <td className="px-4 py-2 capitalize">{user.role}</td>
-                  <td className="px-4 py-2 text-muted-foreground">
-                    {new Intl.DateTimeFormat("en", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                    }).format(new Date(user.createdAt ?? Date.now()))}
-                  </td>
+      <div className="space-y-6">
+        <CreateUserForm
+          allowedRoles={["user"]}
+          heading="Invite a new user"
+          description="Create shopper or staff accounts. They can update their password after first sign in."
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle>Users</CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="border-b bg-muted/40 text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2">Name</th>
+                  <th className="px-4 py-2">Email</th>
+                  <th className="px-4 py-2">Role</th>
+                  <th className="px-4 py-2">Joined</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id} className="border-b last:border-0">
+                    <td className="px-4 py-2 font-medium">{user.name}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{user.email}</td>
+                    <td className="px-4 py-2 capitalize">{user.role}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {new Intl.DateTimeFormat("en", {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      }).format(new Date(user.createdAt ?? Date.now()))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </div>
+      <div className="space-y-6">
+        <h2 className="text-2xl font-semibold text-foreground">Product catalogue</h2>
+        <p className="text-muted-foreground">
+          Add, edit, and feature refurbished or factory-new devices that appear in marketing pages.
+        </p>
+        <ProductManager products={products} />
+      </div>
     </section>
   );
 }

--- a/app/api/products/[id]/route.ts
+++ b/app/api/products/[id]/route.ts
@@ -1,0 +1,103 @@
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import { getCurrentUser } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import { productPayloadSchema } from "@/lib/product-validation";
+import { ProductModel } from "@/models/product";
+
+function sanitizeHighlights(highlights: string[] | undefined) {
+  return Array.isArray(highlights)
+    ? highlights.map((item) => item.trim()).filter((item) => item.length > 0)
+    : [];
+}
+
+function isValidId(id: string) {
+  return mongoose.Types.ObjectId.isValid(id);
+}
+
+async function ensureAdmin() {
+  const actor = await getCurrentUser();
+  if (!actor) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) } as const;
+  }
+  if (actor.role !== "admin" && actor.role !== "superadmin") {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) } as const;
+  }
+  return { actor } as const;
+}
+
+export async function PUT(request: Request, context: { params: { id: string } }) {
+  try {
+    const { params } = context;
+    if (!isValidId(params.id)) {
+      return NextResponse.json({ error: "Invalid product id" }, { status: 400 });
+    }
+
+    const auth = await ensureAdmin();
+    if ("error" in auth) {
+      return auth.error;
+    }
+
+    const payload = productPayloadSchema.parse(await request.json());
+    const highlights = sanitizeHighlights(payload.highlights);
+
+    await connectDB();
+    const updated = await ProductModel.findByIdAndUpdate(
+      params.id,
+      {
+        $set: {
+          name: payload.name,
+          category: payload.category,
+          description: payload.description,
+          price: payload.price,
+          condition: payload.condition,
+          imageUrl: payload.imageUrl ?? "",
+          featured: payload.featured ?? false,
+          inStock: payload.inStock ?? true,
+          highlights,
+        },
+      },
+      { new: true }
+    );
+
+    if (!updated) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: "Product updated" });
+  } catch (error) {
+    console.error("Update product failed", error);
+    if (error instanceof ZodError) {
+      return NextResponse.json({ error: error.flatten().fieldErrors }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Unable to update product" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, context: { params: { id: string } }) {
+  try {
+    const { params } = context;
+    if (!isValidId(params.id)) {
+      return NextResponse.json({ error: "Invalid product id" }, { status: 400 });
+    }
+
+    const auth = await ensureAdmin();
+    if ("error" in auth) {
+      return auth.error;
+    }
+
+    await connectDB();
+    const deleted = await ProductModel.findByIdAndDelete(params.id);
+    if (!deleted) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: "Product deleted" });
+  } catch (error) {
+    console.error("Delete product failed", error);
+    return NextResponse.json({ error: "Unable to delete product" }, { status: 500 });
+  }
+}

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import { getCurrentUser } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import { productPayloadSchema } from "@/lib/product-validation";
+import { listProducts } from "@/lib/products";
+import { ProductModel } from "@/models/product";
+
+function sanitizeHighlights(highlights: string[] | undefined) {
+  return Array.isArray(highlights)
+    ? highlights.map((item) => item.trim()).filter((item) => item.length > 0)
+    : [];
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const limitParam = url.searchParams.get("limit");
+    const featuredOnly = url.searchParams.get("featured") === "true";
+    const inStockOnly = url.searchParams.get("inStock") === "true";
+
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+    const products = await listProducts({
+      limit: Number.isNaN(limit) ? undefined : limit,
+      featuredOnly,
+      inStockOnly,
+    });
+
+    return NextResponse.json({ products });
+  } catch (error) {
+    console.error("Failed to list products", error);
+    return NextResponse.json({ error: "Unable to load products" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const actor = await getCurrentUser();
+    if (!actor) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (actor.role !== "admin" && actor.role !== "superadmin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const payload = productPayloadSchema.parse(await request.json());
+    const highlights = sanitizeHighlights(payload.highlights);
+
+    await connectDB();
+    await ProductModel.create({
+      name: payload.name,
+      category: payload.category,
+      description: payload.description,
+      price: payload.price,
+      condition: payload.condition,
+      imageUrl: payload.imageUrl ?? "",
+      featured: payload.featured ?? false,
+      inStock: payload.inStock ?? true,
+      highlights,
+    });
+
+    return NextResponse.json({ message: "Product created" }, { status: 201 });
+  } catch (error) {
+    console.error("Create product failed", error);
+    if (error instanceof ZodError) {
+      return NextResponse.json({ error: error.flatten().fieldErrors }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Unable to create product" }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,155 @@
 import Link from "next/link";
 
+import { ProductCard } from "@/components/products/product-card";
 import { Button } from "@/components/ui/button";
+import { listProducts } from "@/lib/products";
 
-export default function HomePage() {
+export default async function HomePage() {
+  const featured = await listProducts({ featuredOnly: true, inStockOnly: true, limit: 6 });
+  const fallbacks = featured.length ? featured : await listProducts({ inStockOnly: true, limit: 6 });
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-muted/40 px-4 text-center">
-      <div className="max-w-2xl space-y-4">
-        <h1 className="text-4xl font-semibold sm:text-5xl">
-          Secure access control for your Next.js commerce platform
-        </h1>
-        <p className="text-lg text-muted-foreground">
-          Role-based authentication with JWT cookies, MongoDB persistence, and middleware guards.
-          Start by creating an account or sign in to see the protected dashboard.
-        </p>
-      </div>
-      <div className="flex flex-wrap items-center justify-center gap-4">
-        <Button asChild>
-          <Link href="/register">Get started</Link>
-        </Button>
-        <Button asChild variant="outline">
-          <Link href="/login">Sign in</Link>
-        </Button>
-      </div>
+    <main className="flex min-h-screen flex-col bg-background">
+      <section className="relative overflow-hidden bg-gradient-to-b from-primary/15 via-background to-background py-20 sm:py-28">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,theme(colors.primary/20),transparent_55%)]" />
+        <div className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+          <div className="space-y-8 text-left">
+            <span className="inline-flex items-center rounded-full bg-secondary px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-secondary-foreground">
+              Refurbished laptops & electronics
+            </span>
+            <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              Premium devices, renewed with precision and ready to perform
+            </h1>
+            <p className="max-w-xl text-lg text-muted-foreground">
+              Discover enterprise-grade laptops, tablets, and accessories that undergo a 50-point
+              quality check, professional refurbishment, and ship with reliable warranty coverage.
+            </p>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button asChild size="lg">
+                <Link href="/products">Browse catalogue</Link>
+              </Button>
+              <Button asChild variant="outline" size="lg">
+                <Link href="/register">Create business account</Link>
+              </Button>
+            </div>
+            <dl className="grid gap-6 pt-6 text-muted-foreground sm:grid-cols-3">
+              <div>
+                <dt className="text-sm uppercase tracking-wide">Diagnostics</dt>
+                <dd className="text-2xl font-semibold text-foreground">50+ point QA</dd>
+              </div>
+              <div>
+                <dt className="text-sm uppercase tracking-wide">Warranty</dt>
+                <dd className="text-2xl font-semibold text-foreground">6 month cover</dd>
+              </div>
+              <div>
+                <dt className="text-sm uppercase tracking-wide">Turnaround</dt>
+                <dd className="text-2xl font-semibold text-foreground">48h dispatch</dd>
+              </div>
+            </dl>
+          </div>
+          <div className="relative rounded-3xl border border-primary/20 bg-card/80 p-8 shadow-xl shadow-primary/10">
+            <div className="absolute -left-10 top-10 hidden size-32 rounded-full bg-primary/10 blur-3xl lg:block" />
+            <div className="absolute -right-10 bottom-10 hidden size-32 rounded-full bg-secondary/50 blur-3xl lg:block" />
+            <div className="relative space-y-6">
+              <h2 className="text-2xl font-semibold text-foreground">Why teams choose Rajesh Renewed</h2>
+              <ul className="space-y-4 text-sm text-muted-foreground">
+                <li className="flex items-start gap-3">
+                  <span className="mt-1 inline-flex size-2.5 rounded-full bg-primary" aria-hidden />
+                  Certified components, thermal repaste, and battery health above 80% on every laptop.
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-1 inline-flex size-2.5 rounded-full bg-primary" aria-hidden />
+                  Enterprise imaging, asset tagging, and desk delivery for onboarding at scale.
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-1 inline-flex size-2.5 rounded-full bg-primary" aria-hidden />
+                  Flexible upgrade paths and buy-back options that keep your fleet future ready.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-border/60 bg-background py-16 sm:py-20">
+        <div className="mx-auto max-w-6xl px-6">
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="rounded-2xl border border-border bg-secondary/40 p-8 shadow-sm">
+              <h3 className="text-xl font-semibold text-foreground">Certified refurbishment</h3>
+              <p className="mt-3 text-sm text-muted-foreground">
+                Devices undergo full diagnostic testing, component-level repairs, and BIOS updates by
+                manufacturer-trained engineers.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-border bg-secondary/40 p-8 shadow-sm">
+              <h3 className="text-xl font-semibold text-foreground">Warranty & support</h3>
+              <p className="mt-3 text-sm text-muted-foreground">
+                Enjoy 6-month coverage with instant swap options, plus responsive support from our
+                service desk in under 2 hours.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-border bg-secondary/40 p-8 shadow-sm">
+              <h3 className="text-xl font-semibold text-foreground">Sustainable savings</h3>
+              <p className="mt-3 text-sm text-muted-foreground">
+                Extend device life cycles, reduce e-waste, and unlock up to 60% savings compared to
+                brand-new procurement.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-background py-16 sm:py-24" id="featured">
+        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6">
+          <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-end">
+            <div className="space-y-3">
+              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+                Ready-to-ship highlights
+              </h2>
+              <p className="max-w-2xl text-muted-foreground">
+                Hand-picked devices with fresh batteries, SSD upgrades, and professional calibration
+                to fit remote, hybrid, or on-site teams.
+              </p>
+            </div>
+            <Button asChild variant="secondary" size="lg">
+              <Link href="/products">View all products</Link>
+            </Button>
+          </div>
+          {fallbacks.length ? (
+            <div className="grid gap-8 sm:grid-cols-2 xl:grid-cols-3">
+              {fallbacks.map((product) => (
+                <div key={product.id} id={product.id} className="scroll-mt-24">
+                  <ProductCard product={product} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-border/70 bg-secondary/30 px-6 py-16 text-center text-muted-foreground">
+              New inventory will appear here once added from the admin panel.
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="border-t border-border/60 bg-secondary/40 py-16 sm:py-24">
+        <div className="mx-auto max-w-4xl space-y-6 px-6 text-center">
+          <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+            Need a custom rollout or bulk refresh?
+          </h2>
+          <p className="text-lg text-muted-foreground">
+            Partner with our refurbishment experts for asset imaging, logistics, and lifecycle
+            planning tailored to your workforce.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Button asChild size="lg">
+              <Link href="/register">Talk to sales</Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/login">Existing customer sign in</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
     </main>
   );
 }

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+import { ProductCard } from "@/components/products/product-card";
+import { Button } from "@/components/ui/button";
+import { listProducts } from "@/lib/products";
+
+export const metadata = {
+  title: "Products",
+  description: "Explore refurbished laptops, tablets, and accessories ready to ship.",
+};
+
+export default async function ProductsPage() {
+  const products = await listProducts({});
+
+  return (
+    <main className="flex min-h-screen flex-col bg-background">
+      <section className="relative overflow-hidden bg-gradient-to-b from-primary/10 via-background to-background py-20 sm:py-28">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,theme(colors.primary/20),transparent_55%)]" />
+        <div className="mx-auto max-w-5xl space-y-8 px-6 text-center">
+          <span className="inline-flex items-center justify-center rounded-full bg-secondary px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-secondary-foreground">
+            Available inventory
+          </span>
+          <h1 className="text-4xl font-semibold text-foreground sm:text-5xl">Your next device, renewed</h1>
+          <p className="text-lg text-muted-foreground">
+            Each product listed here has been professionally refurbished, data-wiped, and certified for
+            business-ready deployment. Filter by category to find the right fit for your team.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Button asChild size="lg">
+              <Link href="#catalogue">Shop inventory</Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/register">Request procurement help</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-background py-16 sm:py-24" id="catalogue">
+        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6">
+          <div className="space-y-3 text-center">
+            <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">Certified catalogue</h2>
+            <p className="text-muted-foreground">
+              Laptops, tablets, monitors, and accessories—all renewed, stress-tested, and backed by
+              warranty.
+            </p>
+          </div>
+          {products.length ? (
+            <div className="grid gap-8 sm:grid-cols-2 xl:grid-cols-3">
+              {products.map((product) => (
+                <div key={product.id} id={product.id} className="scroll-mt-24">
+                  <ProductCard product={product} showCta={false} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-border/70 bg-secondary/30 px-6 py-16 text-center text-muted-foreground">
+              No products available yet. Add items from the admin dashboard to populate the catalogue.
+            </div>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/products/product-card.tsx
+++ b/components/products/product-card.tsx
@@ -1,0 +1,85 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ProductSummary } from "@/lib/products";
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: "INR",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+interface ProductCardProps {
+  product: ProductSummary;
+  showCta?: boolean;
+}
+
+export function ProductCard({ product, showCta = true }: ProductCardProps) {
+  const conditionLabel =
+    product.condition === "refurbished" ? "Certified refurbished" : "Factory sealed";
+
+  return (
+    <Card className="group flex h-full flex-col overflow-hidden border-border/70 bg-card/90 backdrop-blur">
+      <div className="relative h-48 w-full overflow-hidden bg-gradient-to-br from-secondary/80 via-secondary to-secondary/40">
+        {product.imageUrl ? (
+          <Image
+            src={product.imageUrl}
+            alt={product.name}
+            fill
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 33vw, 25vw"
+            priority={false}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-secondary/70 text-sm font-medium text-muted-foreground">
+            Visual coming soon
+          </div>
+        )}
+        <span className="absolute left-4 top-4 inline-flex items-center rounded-full bg-primary/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-foreground shadow-sm">
+          {conditionLabel}
+        </span>
+        {!product.inStock ? (
+          <span className="absolute right-4 top-4 inline-flex items-center rounded-full bg-destructive/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-sm">
+            Out of stock
+          </span>
+        ) : null}
+      </div>
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl font-semibold text-foreground">{product.name}</CardTitle>
+        <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          {product.category}
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col justify-between gap-6">
+        <div className="space-y-3">
+          <p className="line-clamp-3 text-sm text-muted-foreground">{product.description}</p>
+          {product.highlights.length ? (
+            <ul className="space-y-1 text-sm text-muted-foreground">
+              {product.highlights.slice(0, 3).map((highlight) => (
+                <li key={highlight} className="flex items-center gap-2">
+                  <span className="inline-flex size-1.5 rounded-full bg-primary/80" aria-hidden />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm uppercase text-muted-foreground">Starting at</p>
+            <p className="text-2xl font-semibold text-primary">{formatCurrency(product.price)}</p>
+          </div>
+          {showCta ? (
+            <Button asChild variant="secondary">
+              <Link href={`/products#${product.id}`}>View details</Link>
+            </Button>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/products/product-form.tsx
+++ b/components/products/product-form.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { MAX_PRODUCT_HIGHLIGHTS, productConditions } from "@/lib/product-constants";
+import type { ProductSummary } from "@/lib/products";
+
+interface ProductFormProps {
+  mode: "create" | "update";
+  product?: ProductSummary;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+const conditionLabels: Record<(typeof productConditions)[number], string> = {
+  refurbished: "Certified refurbished",
+  new: "Brand new",
+};
+
+type ProductFormValues = {
+  name: string;
+  category: string;
+  description: string;
+  price: number;
+  condition: (typeof productConditions)[number];
+  imageUrl: string;
+  featured: boolean;
+  inStock: boolean;
+  highlights: string;
+};
+
+export function ProductForm({ mode, product, onSuccess, onCancel }: ProductFormProps) {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        name: z.string().min(3, "Name must be at least 3 characters"),
+        category: z.string().min(2, "Category must be at least 2 characters"),
+        description: z.string().min(10, "Description must be at least 10 characters"),
+        price: z.coerce.number().min(0, "Price must be 0 or greater"),
+        condition: z.enum(productConditions),
+        imageUrl: z
+          .string()
+          .url("Enter a valid URL")
+          .or(z.literal(""))
+          .default(""),
+        featured: z.boolean().default(false),
+        inStock: z.boolean().default(true),
+        highlights: z
+          .string()
+          .max(800, "Highlights should be under 800 characters")
+          .optional()
+          .default(""),
+      }),
+    []
+  );
+
+  const form = useForm<ProductFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: product?.name ?? "",
+      category: product?.category ?? "",
+      description: product?.description ?? "",
+      price: product?.price ?? 0,
+      condition: product?.condition ?? "refurbished",
+      imageUrl: product?.imageUrl ?? "",
+      featured: product?.featured ?? false,
+      inStock: product?.inStock ?? true,
+      highlights: product?.highlights?.join("\n") ?? "",
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = form;
+
+  const submitHandler = handleSubmit(async (values) => {
+    setServerError(null);
+
+    const highlights = values.highlights
+      .split("\n")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+
+    if (highlights.length > MAX_PRODUCT_HIGHLIGHTS) {
+      setServerError(`You can add up to ${MAX_PRODUCT_HIGHLIGHTS} highlights.`);
+      return;
+    }
+
+    const payload = {
+      name: values.name,
+      category: values.category,
+      description: values.description,
+      price: values.price,
+      condition: values.condition,
+      imageUrl: values.imageUrl,
+      featured: values.featured,
+      inStock: values.inStock,
+      highlights,
+    };
+
+    try {
+      const endpoint = mode === "create" ? "/api/products" : `/api/products/${product?.id}`;
+      const method = mode === "create" ? "POST" : "PUT";
+
+      const response = await fetch(endpoint, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error
+          ? typeof data.error === "string"
+            ? data.error
+            : Object.values<string[]>(data.error)[0]?.[0] ?? "Unable to save product"
+          : "Unable to save product";
+        setServerError(message);
+        toast.error(message);
+        return;
+      }
+
+      toast.success(mode === "create" ? "Product created" : "Product updated");
+      if (mode === "create") {
+        reset({
+          name: "",
+          category: "",
+          description: "",
+          price: 0,
+          condition: "refurbished",
+          imageUrl: "",
+          featured: false,
+          inStock: true,
+          highlights: "",
+        });
+      }
+      router.refresh();
+      onSuccess?.();
+    } catch (error) {
+      console.error(error);
+      const message = "Unable to reach the server. Please try again.";
+      setServerError(message);
+      toast.error(message);
+    }
+  });
+
+  const title = mode === "create" ? "Add a new product" : `Update ${product?.name ?? "product"}`;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-2xl font-semibold text-foreground">{title}</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Fill in product details to showcase laptops and electronics in the storefront.
+        </p>
+      </CardHeader>
+      <form onSubmit={submitHandler} className="space-y-6">
+        <CardContent className="grid gap-6 sm:grid-cols-2">
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="name">Product name</Label>
+            <Input id="name" placeholder="ThinkPad X1 Carbon" {...register("name")} />
+            {errors.name ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.name.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="category">Category</Label>
+            <Input id="category" placeholder="Ultrabook" {...register("category")} />
+            {errors.category ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.category.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="price">Price (₹)</Label>
+            <Input id="price" type="number" step="0.01" min="0" {...register("price", { valueAsNumber: true })} />
+            {errors.price ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.price.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="condition">Condition</Label>
+            <select
+              id="condition"
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+              {...register("condition")}
+            >
+              {productConditions.map((condition) => (
+                <option key={condition} value={condition}>
+                  {conditionLabels[condition]}
+                </option>
+              ))}
+            </select>
+            {errors.condition ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.condition.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="imageUrl">Image URL</Label>
+            <Input id="imageUrl" placeholder="https://images.example.com/device.jpg" {...register("imageUrl")} />
+            {errors.imageUrl ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.imageUrl.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              placeholder="Share the device story, refurbishment process, and warranty coverage."
+              className="min-h-[140px]"
+              {...register("description")}
+            />
+            {errors.description ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.description.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="highlights">Highlights</Label>
+            <Textarea
+              id="highlights"
+              placeholder={`Add up to ${MAX_PRODUCT_HIGHLIGHTS} bullet points. Enter one per line.`}
+              className="min-h-[120px]"
+              {...register("highlights")}
+            />
+            <p className="text-xs text-muted-foreground">
+              Showcase key selling points, warranty terms, or bundled accessories.
+            </p>
+            {errors.highlights ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.highlights.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex flex-col gap-6 sm:col-span-2 sm:flex-row">
+            <label className="flex items-center gap-3 rounded-lg border border-input bg-secondary/50 px-4 py-3 text-sm font-medium text-foreground shadow-sm">
+              <input
+                type="checkbox"
+                className="size-4 rounded border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                {...register("featured")}
+              />
+              Highlight on landing page
+            </label>
+            <label className="flex items-center gap-3 rounded-lg border border-input bg-secondary/50 px-4 py-3 text-sm font-medium text-foreground shadow-sm">
+              <input
+                type="checkbox"
+                className="size-4 rounded border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                {...register("inStock")}
+              />
+              Available in stock
+            </label>
+          </div>
+          {serverError ? (
+            <div className="sm:col-span-2">
+              <p className="text-sm text-destructive" role="alert">
+                {serverError}
+              </p>
+            </div>
+          ) : null}
+        </CardContent>
+        <CardFooter className="flex flex-col justify-end gap-3 sm:flex-row">
+          {onCancel ? (
+            <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+          ) : null}
+          <Button type="submit" className="sm:ml-auto" disabled={isSubmitting}>
+            {isSubmitting ? "Saving..." : mode === "create" ? "Create product" : "Save changes"}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/components/products/product-manager.tsx
+++ b/components/products/product-manager.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ProductSummary } from "@/lib/products";
+
+import { ProductForm } from "./product-form";
+
+interface ProductManagerProps {
+  products: ProductSummary[];
+}
+
+export function ProductManager({ products }: ProductManagerProps) {
+  const router = useRouter();
+  const [editingProduct, setEditingProduct] = useState<ProductSummary | null>(null);
+
+  async function handleDelete(id: string) {
+    const confirmed = window.confirm("Are you sure you want to delete this product?");
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/products/${id}`, { method: "DELETE" });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error ?? "Unable to delete product";
+        toast.error(message);
+        return;
+      }
+
+      toast.success("Product removed");
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to reach the server. Please try again.");
+    }
+  }
+
+  return (
+    <section className="space-y-8">
+      <ProductForm mode="create" onSuccess={() => router.refresh()} />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl font-semibold text-foreground">Inventory</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Manage the devices that appear on the landing page and catalogue.
+          </p>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b bg-muted/40 text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2">Product</th>
+                <th className="px-4 py-2">Category</th>
+                <th className="px-4 py-2">Condition</th>
+                <th className="px-4 py-2">Price</th>
+                <th className="px-4 py-2">Featured</th>
+                <th className="px-4 py-2">Stock</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {products.length ? (
+                products.map((product) => (
+                  <tr key={product.id} className="border-b last:border-0">
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      <div className="space-y-1">
+                        <span>{product.name}</span>
+                        <p className="text-xs text-muted-foreground line-clamp-2">
+                          {product.description}
+                        </p>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{product.category}</td>
+                    <td className="px-4 py-3 capitalize text-muted-foreground">{product.condition}</td>
+                    <td className="px-4 py-3 font-semibold text-primary">
+                      {new Intl.NumberFormat("en-IN", {
+                        style: "currency",
+                        currency: "INR",
+                        maximumFractionDigits: 0,
+                      }).format(product.price)}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {product.featured ? "Yes" : "No"}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {product.inStock ? "Available" : "Out of stock"}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setEditingProduct(product)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => handleDelete(product.id)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td className="px-4 py-6 text-center text-muted-foreground" colSpan={7}>
+                    Add your first product to populate the storefront.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {editingProduct ? (
+        <ProductForm
+          key={editingProduct.id}
+          mode="update"
+          product={editingProduct}
+          onSuccess={() => {
+            setEditingProduct(null);
+            router.refresh();
+          }}
+          onCancel={() => setEditingProduct(null)}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/lib/product-constants.ts
+++ b/lib/product-constants.ts
@@ -1,0 +1,5 @@
+export const productConditions = ["refurbished", "new"] as const;
+
+export type ProductCondition = (typeof productConditions)[number];
+
+export const MAX_PRODUCT_HIGHLIGHTS = 6;

--- a/lib/product-validation.ts
+++ b/lib/product-validation.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+import { MAX_PRODUCT_HIGHLIGHTS, productConditions } from "@/lib/product-constants";
+
+export const productPayloadSchema = z.object({
+  name: z.string().min(3, "Name must be at least 3 characters"),
+  category: z.string().min(2, "Category must be at least 2 characters"),
+  description: z.string().min(10, "Description must be at least 10 characters"),
+  price: z.coerce.number().min(0, "Price must be 0 or greater"),
+  condition: z.enum(productConditions),
+  imageUrl: z
+    .string()
+    .url("Enter a valid image URL")
+    .or(z.literal(""))
+    .optional()
+    .default(""),
+  featured: z.boolean().optional().default(false),
+  inStock: z.boolean().optional().default(true),
+  highlights: z
+    .array(z.string().min(1, "Highlights cannot be empty"))
+    .max(
+      MAX_PRODUCT_HIGHLIGHTS,
+      `You can add up to ${MAX_PRODUCT_HIGHLIGHTS} highlights`
+    )
+    .optional()
+    .default([]),
+});
+
+export type ProductPayload = z.infer<typeof productPayloadSchema>;

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,74 @@
+import type { FilterQuery } from "mongoose";
+
+import { connectDB } from "@/lib/db";
+import type { ProductCondition } from "@/lib/product-constants";
+import { ProductModel, type ProductDocument } from "@/models/product";
+
+export interface ProductSummary {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  price: number;
+  condition: ProductCondition;
+  imageUrl: string | null;
+  highlights: string[];
+  featured: boolean;
+  inStock: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListProductsOptions {
+  limit?: number;
+  featuredOnly?: boolean;
+  inStockOnly?: boolean;
+}
+
+function mapProduct(product: ProductDocument): ProductSummary {
+  return {
+    id: product._id.toString(),
+    name: product.name,
+    category: product.category,
+    description: product.description,
+    price: product.price,
+    condition: product.condition,
+    imageUrl: product.imageUrl || null,
+    highlights: Array.isArray(product.highlights)
+      ? product.highlights.filter((item): item is string => Boolean(item && item.trim()))
+      : [],
+    featured: Boolean(product.featured),
+    inStock: Boolean(product.inStock),
+    createdAt: product.createdAt ? product.createdAt.toISOString() : new Date().toISOString(),
+    updatedAt: product.updatedAt ? product.updatedAt.toISOString() : new Date().toISOString(),
+  };
+}
+
+export async function listProducts(options: ListProductsOptions = {}): Promise<ProductSummary[]> {
+  await connectDB();
+
+  const filters: FilterQuery<ProductDocument> = {};
+  if (options.featuredOnly) {
+    filters.featured = true;
+  }
+  if (options.inStockOnly) {
+    filters.inStock = true;
+  }
+
+  let query = ProductModel.find(filters).sort({ featured: -1, createdAt: -1 });
+  if (typeof options.limit === "number" && Number.isFinite(options.limit)) {
+    query = query.limit(Math.max(0, options.limit));
+  }
+
+  const products = (await query.lean()) as unknown as ProductDocument[];
+  return products.map(mapProduct);
+}
+
+export async function getProductById(id: string): Promise<ProductSummary | null> {
+  await connectDB();
+  const product = await ProductModel.findById(id).lean<ProductDocument | null>();
+  if (!product) {
+    return null;
+  }
+  return mapProduct(product);
+}

--- a/models/product.ts
+++ b/models/product.ts
@@ -1,0 +1,60 @@
+import mongoose, { Schema, type InferSchemaType } from "mongoose";
+
+import { productConditions } from "@/lib/product-constants";
+
+const ProductSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    category: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    description: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    price: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+    condition: {
+      type: String,
+      enum: productConditions,
+      default: "refurbished",
+    },
+    imageUrl: {
+      type: String,
+      default: "",
+      trim: true,
+    },
+    highlights: {
+      type: [String],
+      default: [],
+    },
+    featured: {
+      type: Boolean,
+      default: false,
+    },
+    inStock: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+export type ProductDocument = InferSchemaType<typeof ProductSchema> & {
+  _id: mongoose.Types.ObjectId;
+};
+
+export const ProductModel =
+  mongoose.models.Product || mongoose.model<ProductDocument>("Product", ProductSchema);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add product model, validation helpers, and API routes to list, create, update, and delete catalogue entries
- build product management UI for admins including reusable form controls and textarea component
- redesign the landing experience and add a products catalogue page that surfaces database-backed product cards
- allow remote product imagery in Next.js configuration

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d27120e7c0832bb3e4310dfbd892c6