### PR TITLE
Add global navigation shell and admin listings

### DIFF
--- a/app/(protected)/admin/categories/page.tsx
+++ b/app/(protected)/admin/categories/page.tsx
@@ -1,0 +1,36 @@
+import { Metadata } from "next";
+
+import { CategoriesTable } from "@/components/admin/categories-table";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { listCategories } from "@/lib/categories";
+
+export const metadata: Metadata = {
+  title: "Categories | Rajesh Control",
+};
+
+export default async function AdminCategoriesPage() {
+  const categories = await listCategories();
+
+  return (
+    <section className="space-y-10">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold text-foreground">Category library</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Track the distribution of devices across product categories. Use search and sorting to surface
+          focus areas for merchandising or sourcing.
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold text-foreground">All categories</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Each category aggregates the latest product count and refresh timestamp from the catalogue.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <CategoriesTable data={categories} />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -1,21 +1,104 @@
+import Link from "next/link";
+import { ArrowUpRight, Boxes, Layers, UsersRound } from "lucide-react";
+
 import { CreateUserForm } from "@/components/auth/create-user-form";
-import { ProductManager } from "@/components/products/product-manager";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { listCategories } from "@/lib/categories";
 import { listProducts } from "@/lib/products";
 import { listUsers } from "@/lib/users";
 
 export default async function AdminPage() {
   const users = await listUsers();
   const products = await listProducts();
+  const categories = await listCategories();
+
+  const featuredCount = products.filter((product) => product.featured).length;
 
   return (
     <section className="space-y-12">
-      <div className="space-y-2">
+      <div className="space-y-3">
         <h1 className="text-3xl font-semibold text-foreground">Admin overview</h1>
         <p className="text-muted-foreground">
-          Review user accounts and curate the catalogue that powers the storefront experience.
+          Review your key metrics at a glance and jump into catalogue or user management tasks.
         </p>
       </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Total products</CardTitle>
+            <Boxes className="h-4 w-4 text-primary" aria-hidden />
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-foreground">{products.length}</p>
+            <p className="text-xs text-muted-foreground">{featuredCount} featured on the storefront</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Categories</CardTitle>
+            <Layers className="h-4 w-4 text-primary" aria-hidden />
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-foreground">{categories.length}</p>
+            <p className="text-xs text-muted-foreground">Aggregated from current products</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Active users</CardTitle>
+            <UsersRound className="h-4 w-4 text-primary" aria-hidden />
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-foreground">{users.length}</p>
+            <p className="text-xs text-muted-foreground">Includes shoppers and internal staff</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-lg font-semibold text-foreground">
+              Products
+              <ArrowUpRight className="h-4 w-4 text-muted-foreground" aria-hidden />
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Search and sort the entire inventory, update pricing, and feature the right devices.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Link
+              href="/admin/products"
+              className="inline-flex items-center gap-2 rounded-md border border-border/60 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary hover:text-primary"
+            >
+              Go to product catalogue
+              <ArrowUpRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-lg font-semibold text-foreground">
+              Categories
+              <ArrowUpRight className="h-4 w-4 text-muted-foreground" aria-hidden />
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Understand how your assortment is structured and spot opportunities to balance inventory.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Link
+              href="/admin/categories"
+              className="inline-flex items-center gap-2 rounded-md border border-border/60 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary hover:text-primary"
+            >
+              Review category listing
+              <ArrowUpRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+
       <div className="space-y-6">
         <CreateUserForm
           allowedRoles={["user"]}
@@ -24,7 +107,8 @@ export default async function AdminPage() {
         />
         <Card>
           <CardHeader>
-            <CardTitle>Users</CardTitle>
+            <CardTitle className="text-lg font-semibold text-foreground">Latest users</CardTitle>
+            <p className="text-sm text-muted-foreground">An at-a-glance view of everyone with platform access.</p>
           </CardHeader>
           <CardContent className="overflow-x-auto">
             <table className="min-w-full text-left text-sm">
@@ -55,13 +139,6 @@ export default async function AdminPage() {
             </table>
           </CardContent>
         </Card>
-      </div>
-      <div className="space-y-6">
-        <h2 className="text-2xl font-semibold text-foreground">Product catalogue</h2>
-        <p className="text-muted-foreground">
-          Add, edit, and feature refurbished or factory-new devices that appear in marketing pages.
-        </p>
-        <ProductManager products={products} />
       </div>
     </section>
   );

--- a/app/(protected)/admin/products/page.tsx
+++ b/app/(protected)/admin/products/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+import { ProductManager } from "@/components/products/product-manager";
+import { listProducts } from "@/lib/products";
+
+export const metadata: Metadata = {
+  title: "Product catalogue | Rajesh Control",
+};
+
+export default async function AdminProductsPage() {
+  const products = await listProducts();
+
+  return (
+    <section className="space-y-10">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold text-foreground">Product catalogue</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Browse every item currently listed on the storefront. Use the search and sorting tools to find
+          specific devices, update existing entries, or remove discontinued stock.
+        </p>
+      </div>
+      <ProductManager products={products} />
+    </section>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from "react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
-import { LogoutButton } from "@/components/auth/logout-button";
+import { ProtectedAppShell } from "@/components/navigation/protected-app-shell";
 import { getCurrentUser } from "@/lib/auth";
 import type { Role } from "@/models/user";
 
@@ -13,6 +12,8 @@ const navLinks: Array<{ href: string; label: string; roles: Role[] }> = [
     roles: ["user", "admin", "superadmin"],
   },
   { href: "/admin", label: "Admin", roles: ["admin", "superadmin"] },
+  { href: "/admin/products", label: "Products", roles: ["admin", "superadmin"] },
+  { href: "/admin/categories", label: "Categories", roles: ["admin", "superadmin"] },
   { href: "/superadmin", label: "Super Admin", roles: ["superadmin"] },
 ];
 
@@ -28,35 +29,8 @@ export default async function ProtectedLayout({
   }
 
   return (
-    <div className="min-h-screen bg-muted/10">
-      <header className="border-b bg-background">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-sm text-muted-foreground">Signed in as</p>
-            <p className="font-semibold">
-              {user.name}{" "}
-              <span className="text-sm text-muted-foreground">
-                ({user.role})
-              </span>
-            </p>
-          </div>
-          <nav className="flex flex-wrap items-center gap-3">
-            {navLinks
-              .filter((link) => link.roles.includes(user.role))
-              .map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="text-sm font-medium text-muted-foreground hover:text-foreground"
-                >
-                  {link.label}
-                </Link>
-              ))}
-            <LogoutButton />
-          </nav>
-        </div>
-      </header>
-      <main className="mx-auto w-full max-w-5xl px-6 py-10">{children}</main>
-    </div>
+    <ProtectedAppShell user={user} navLinks={navLinks}>
+      {children}
+    </ProtectedAppShell>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
 import { ToasterProvider } from "@/components/providers/toaster-provider";
+import { SiteNavbar } from "@/components/navigation/site-navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,12 +27,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        suppressHydrationWarning
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body suppressHydrationWarning className={`${geistSans.variable} ${geistMono.variable} bg-background antialiased`}>
+        <SiteNavbar />
         <ToasterProvider />
-        {children}
+        <div className="min-h-screen">{children}</div>
       </body>
     </html>
   );

--- a/components/admin/categories-table.tsx
+++ b/components/admin/categories-table.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Folder, FolderSearch } from "lucide-react";
+
+import { DataTable } from "@/components/data-table/data-table";
+import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import type { CategorySummary } from "@/lib/categories";
+
+interface CategoriesTableProps {
+  data: CategorySummary[];
+}
+
+export function CategoriesTable({ data }: CategoriesTableProps) {
+  const columns = React.useMemo<ColumnDef<CategorySummary>[]>(
+    () => [
+      {
+        accessorKey: "name",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Category" />,
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <Folder className="h-4 w-4 text-muted-foreground" aria-hidden />
+            <span className="font-medium text-foreground">{row.original.name}</span>
+          </div>
+        ),
+      },
+      {
+        accessorKey: "productCount",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Products" align="right" />,
+        cell: ({ getValue }) => (
+          <div className="text-right font-semibold">{getValue<number>()}</div>
+        ),
+      },
+      {
+        accessorKey: "lastUpdated",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Last updated" />, 
+        cell: ({ getValue }) => {
+          const value = getValue<string>();
+          const formatted = value ? new Date(value).toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" }) : "-";
+          return <span className="text-sm text-muted-foreground">{formatted}</span>;
+        },
+      },
+    ],
+    [],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      searchKey="name"
+      searchPlaceholder="Search categories by name"
+      emptyState={
+        <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
+          <FolderSearch className="h-10 w-10" aria-hidden />
+          <p className="text-sm font-medium">No categories found</p>
+          <p className="text-xs">Add products with category information to populate this list.</p>
+        </div>
+      }
+    />
+  );
+}

--- a/components/admin/products-table.tsx
+++ b/components/admin/products-table.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as React from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { BadgeCheck, PackageSearch } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/data-table/data-table";
+import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import type { ProductSummary } from "@/lib/products";
+
+interface ProductsTableProps {
+  data: ProductSummary[];
+  onEdit: (product: ProductSummary) => void;
+  onDelete: (id: string) => void;
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-IN", {
+  style: "currency",
+  currency: "INR",
+  maximumFractionDigits: 0,
+});
+
+export function ProductsTable({ data, onEdit, onDelete }: ProductsTableProps) {
+  const columns = React.useMemo<ColumnDef<ProductSummary>[]>(
+    () => [
+      {
+        accessorKey: "name",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Product" />,
+        cell: ({ row }) => (
+          <div className="max-w-xs space-y-1">
+            <p className="font-medium text-foreground">{row.original.name}</p>
+            <p className="text-xs text-muted-foreground line-clamp-2">{row.original.description}</p>
+          </div>
+        ),
+      },
+      {
+        accessorKey: "category",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Category" />,
+        cell: ({ getValue }) => <span className="text-sm text-muted-foreground">{getValue<string>()}</span>,
+      },
+      {
+        accessorKey: "condition",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Condition" />,
+        cell: ({ getValue }) => (
+          <span className="text-sm capitalize text-muted-foreground">{getValue<string>()}</span>
+        ),
+      },
+      {
+        accessorKey: "price",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Price" align="right" />,
+        cell: ({ getValue }) => (
+          <div className="text-right font-semibold text-primary">{currencyFormatter.format(getValue<number>())}</div>
+        ),
+      },
+      {
+        accessorKey: "featured",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Featured" />,
+        cell: ({ getValue }) =>
+          getValue<boolean>() ? (
+            <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary">
+              <BadgeCheck className="h-4 w-4" aria-hidden /> Featured
+            </span>
+          ) : (
+            <span className="text-sm text-muted-foreground">Standard</span>
+          ),
+        enableSorting: false,
+      },
+      {
+        accessorKey: "inStock",
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Stock" />,
+        cell: ({ getValue }) => (
+          <span className="text-sm font-medium">
+            {getValue<boolean>() ? "Available" : "Out of stock"}
+          </span>
+        ),
+        enableSorting: false,
+      },
+      {
+        id: "actions",
+        header: () => <span className="sr-only">Actions</span>,
+        cell: ({ row }) => (
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" size="sm" onClick={() => onEdit(row.original)}>
+              Edit
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => onDelete(row.original.id)}
+            >
+              Delete
+            </Button>
+          </div>
+        ),
+        enableSorting: false,
+      },
+    ],
+    [onEdit, onDelete],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      searchKey="name"
+      searchPlaceholder="Search products by name"
+      emptyState={
+        <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
+          <PackageSearch className="h-10 w-10" aria-hidden />
+          <p className="text-sm font-medium">No products found</p>
+          <p className="text-xs">Try adjusting your filters or add a new product.</p>
+        </div>
+      }
+    />
+  );
+}

--- a/components/data-table/data-table-column-header.tsx
+++ b/components/data-table/data-table-column-header.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import type { Column } from "@tanstack/react-table";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DataTableColumnHeaderProps<TData, TValue> {
+  column: Column<TData, TValue>;
+  title: string;
+  align?: "left" | "center" | "right";
+}
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  align = "left",
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  const sorted = column.getIsSorted();
+
+  if (!column.getCanSort()) {
+    return (
+      <span className={cn("text-xs font-semibold uppercase tracking-wide text-muted-foreground", align === "center" && "text-center", align === "right" && "text-right")}>
+        {title}
+      </span>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "-ml-3 h-8 px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground",
+        align === "center" && "justify-center text-center",
+        align === "right" && "justify-end text-right",
+      )}
+      onClick={() => column.toggleSorting(sorted === "asc")}
+    >
+      <span>{title}</span>
+      {sorted === "asc" ? (
+        <ArrowUp className="ml-2 h-3.5 w-3.5" aria-hidden />
+      ) : sorted === "desc" ? (
+        <ArrowDown className="ml-2 h-3.5 w-3.5" aria-hidden />
+      ) : (
+        <ArrowUpDown className="ml-2 h-3.5 w-3.5" aria-hidden />
+      )}
+    </Button>
+  );
+}

--- a/components/navigation/protected-app-shell.tsx
+++ b/components/navigation/protected-app-shell.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+
+import { LogoutButton } from "@/components/auth/logout-button";
+import { Button } from "@/components/ui/button";
+import type { SessionUser } from "@/lib/auth";
+import type { Role } from "@/models/user";
+import { cn } from "@/lib/utils";
+
+interface NavLink {
+  href: string;
+  label: string;
+  roles: Role[];
+}
+
+interface ProtectedAppShellProps {
+  user: SessionUser;
+  navLinks: NavLink[];
+  children: React.ReactNode;
+}
+
+export function ProtectedAppShell({ user, navLinks, children }: ProtectedAppShellProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const pathname = usePathname();
+
+  const links = navLinks.filter((link) => link.roles.includes(user.role));
+
+  return (
+    <div className="flex min-h-screen bg-muted/10">
+      {sidebarOpen ? (
+        <div
+          className="fixed inset-0 z-30 bg-background/80 backdrop-blur-sm transition-opacity md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      ) : null}
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-40 flex w-72 flex-col border-r border-border/60 bg-background/95 px-6 py-8 shadow-sm transition-transform duration-200 ease-in-out md:static md:translate-x-0",
+          sidebarOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0",
+        )}
+      >
+        <div className="flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <span className="inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-lg text-primary">
+              R
+            </span>
+            Rajesh Control
+          </Link>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-md border border-border/60 p-2 text-muted-foreground md:hidden"
+            onClick={() => setSidebarOpen(false)}
+            aria-label="Close sidebar"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+        <div className="mt-8 space-y-2 text-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Navigation</p>
+          <nav className="flex flex-col gap-1">
+            {links.map((link) => {
+              const isActive = pathname === link.href || pathname.startsWith(`${link.href}/`);
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={cn(
+                    "rounded-lg px-3 py-2 font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+                    isActive && "bg-primary/10 text-foreground",
+                  )}
+                  onClick={() => setSidebarOpen(false)}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+        <div className="mt-auto space-y-3 rounded-lg border border-border/60 bg-muted/40 p-4 text-sm">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Signed in</p>
+            <p className="font-medium text-foreground">{user.name}</p>
+            <p className="text-xs capitalize text-muted-foreground">{user.role}</p>
+          </div>
+          <LogoutButton />
+        </div>
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <header className="flex h-16 items-center justify-between border-b border-border/60 bg-background/95 px-6">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md border border-border/60 p-2 text-muted-foreground md:hidden"
+              onClick={() => setSidebarOpen(true)}
+              aria-label="Open sidebar"
+            >
+              <Menu className="h-4 w-4" aria-hidden />
+            </button>
+            <div>
+              <p className="text-sm font-medium text-foreground">Welcome back</p>
+              <p className="text-xs text-muted-foreground">
+                Manage catalogue, accounts, and platform content from this admin panel.
+              </p>
+            </div>
+          </div>
+          <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground md:flex">
+            <span>Need help?</span>
+            <Button asChild size="sm" variant="outline">
+              <Link href="/">View storefront</Link>
+            </Button>
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto bg-muted/10 px-6 py-10">
+          <div className="mx-auto max-w-6xl space-y-8">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/navigation/site-navbar.tsx
+++ b/components/navigation/site-navbar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const navLinks = [
+  { href: "/", label: "Home" },
+  { href: "/products", label: "Products" },
+  { href: "#featured", label: "Highlights" },
+];
+
+const authLinks = [
+  { href: "/login", label: "Sign in" },
+  { href: "/register", label: "Create account", primary: true },
+];
+
+const HIDDEN_ON_PATHS = [/^\/dashboard/, /^\/admin/, /^\/superadmin/];
+
+export function SiteNavbar() {
+  const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const shouldHide = HIDDEN_ON_PATHS.some((regex) => regex.test(pathname));
+  if (shouldHide) {
+    return null;
+  }
+
+  return (
+    <header className="sticky top-0 z-40 w-full border-b border-border/60 bg-background/95 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <div className="flex items-center gap-8">
+          <Link href="/" className="flex items-center gap-2 text-base font-semibold text-foreground">
+            <span className="inline-flex size-8 items-center justify-center rounded-full bg-primary/10 text-primary">R</span>
+            Rajesh Renewed
+          </Link>
+          <nav className="hidden items-center gap-6 text-sm font-medium text-muted-foreground md:flex">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cn(
+                  "transition-colors hover:text-foreground",
+                  pathname === link.href ? "text-foreground" : undefined,
+                )}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="hidden items-center gap-2 md:flex">
+          {authLinks.map((link) => (
+            <Button key={link.href} asChild variant={link.primary ? "default" : "ghost"} size="sm">
+              <Link href={link.href}>{link.label}</Link>
+            </Button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-md border border-border/60 p-2 text-muted-foreground md:hidden"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-label={menuOpen ? "Close navigation" : "Open navigation"}
+        >
+          {menuOpen ? <X className="h-5 w-5" aria-hidden /> : <Menu className="h-5 w-5" aria-hidden />}
+        </button>
+      </div>
+      {menuOpen ? (
+        <div className="border-t border-border/60 bg-background/95 px-6 py-4 md:hidden">
+          <nav className="flex flex-col gap-3 text-sm font-medium">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setMenuOpen(false)}
+                className={cn(
+                  "rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
+                  pathname === link.href ? "bg-muted/60 text-foreground" : undefined,
+                )}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="mt-4 flex flex-col gap-2">
+            {authLinks.map((link) => (
+              <Button
+                key={link.href}
+                asChild
+                variant={link.primary ? "default" : "outline"}
+                size="sm"
+                onClick={() => setMenuOpen(false)}
+              >
+                <Link href={link.href}>{link.label}</Link>
+              </Button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/components/products/product-manager.tsx
+++ b/components/products/product-manager.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ProductsTable } from "@/components/admin/products-table";
 import type { ProductSummary } from "@/lib/products";
 
 import { ProductForm } from "./product-form";
@@ -52,76 +53,12 @@ export function ProductManager({ products }: ProductManagerProps) {
             Manage the devices that appear on the landing page and catalogue.
           </p>
         </CardHeader>
-        <CardContent className="overflow-x-auto">
-          <table className="min-w-full text-left text-sm">
-            <thead className="border-b bg-muted/40 text-muted-foreground">
-              <tr>
-                <th className="px-4 py-2">Product</th>
-                <th className="px-4 py-2">Category</th>
-                <th className="px-4 py-2">Condition</th>
-                <th className="px-4 py-2">Price</th>
-                <th className="px-4 py-2">Featured</th>
-                <th className="px-4 py-2">Stock</th>
-                <th className="px-4 py-2 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {products.length ? (
-                products.map((product) => (
-                  <tr key={product.id} className="border-b last:border-0">
-                    <td className="px-4 py-3 font-medium text-foreground">
-                      <div className="space-y-1">
-                        <span>{product.name}</span>
-                        <p className="text-xs text-muted-foreground line-clamp-2">
-                          {product.description}
-                        </p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">{product.category}</td>
-                    <td className="px-4 py-3 capitalize text-muted-foreground">{product.condition}</td>
-                    <td className="px-4 py-3 font-semibold text-primary">
-                      {new Intl.NumberFormat("en-IN", {
-                        style: "currency",
-                        currency: "INR",
-                        maximumFractionDigits: 0,
-                      }).format(product.price)}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {product.featured ? "Yes" : "No"}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {product.inStock ? "Available" : "Out of stock"}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setEditingProduct(product)}
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-destructive hover:text-destructive"
-                          onClick={() => handleDelete(product.id)}
-                        >
-                          Delete
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              ) : (
-                <tr>
-                  <td className="px-4 py-6 text-center text-muted-foreground" colSpan={7}>
-                    Add your first product to populate the storefront.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+        <CardContent>
+          <ProductsTable
+            data={products}
+            onEdit={(product) => setEditingProduct(product)}
+            onDelete={handleDelete}
+          />
         </CardContent>
       </Card>
 

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  ),
+);
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  ),
+);
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+  ),
+);
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot ref={ref} className={cn("bg-muted/50 font-medium", className)} {...props} />
+  ),
+);
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn(
+        "h-12 px-4 text-left align-middle text-xs font-medium text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn("p-4 align-middle text-sm text-foreground", className)}
+      {...props}
+    />
+  ),
+);
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption
+      ref={ref}
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  ),
+);
+TableCaption.displayName = "TableCaption";
+
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,54 @@
+import { connectDB } from "@/lib/db";
+import { ProductModel } from "@/models/product";
+
+export interface CategorySummary {
+  name: string;
+  productCount: number;
+  lastUpdated: string;
+}
+
+interface RawCategorySummary {
+  name: string;
+  productCount: number;
+  lastUpdated: Date | null;
+}
+
+export async function listCategories(): Promise<CategorySummary[]> {
+  await connectDB();
+
+  const categories = (await ProductModel.aggregate<RawCategorySummary>([
+    {
+      $group: {
+        _id: {
+          $cond: {
+            if: {
+              $or: [
+                { $eq: ["$category", null] },
+                { $eq: ["$category", ""] },
+              ],
+            },
+            then: "Uncategorized",
+            else: "$category",
+          },
+        },
+        productCount: { $sum: 1 },
+        lastUpdated: { $max: { $ifNull: ["$updatedAt", "$createdAt"] } },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        name: "$_id",
+        productCount: 1,
+        lastUpdated: 1,
+      },
+    },
+    { $sort: { name: 1 } },
+  ]).exec()) ?? [];
+
+  return categories.map((category) => ({
+    name: category.name,
+    productCount: category.productCount,
+    lastUpdated: (category.lastUpdated ?? new Date()).toISOString(),
+  }));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-slot": "^1.2.3",
+        "@tanstack/react-table": "^8.21.3",
         "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2254,6 +2255,39 @@
         "@tailwindcss/oxide": "4.1.13",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.13"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-slot": "^1.2.3",
+    "@tanstack/react-table": "^8.21.3",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add a sticky storefront navbar and shared layout updates
- replace the protected area chrome with a sidebar shell and refreshed admin overview
- introduce reusable data table utilities and sortable listings for products and categories

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d274eebcac832b8dcf75f2a7767719