### PR TITLE
Improve responsiveness and add dummy product API

### DIFF
--- a/app/api/products/dummy/route.ts
+++ b/app/api/products/dummy/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "../seed/route";

--- a/app/api/products/seed/route.ts
+++ b/app/api/products/seed/route.ts
@@ -2,40 +2,9 @@ import { NextResponse } from "next/server";
 
 import { getCurrentUser } from "@/lib/auth";
 import { connectDB } from "@/lib/db";
-import { productConditions } from "@/lib/product-constants";
+import { createDummyProductBatch, dummySeedCategories } from "@/lib/dummy-products";
 import { ProductModel } from "@/models/product";
 import { CategoryModel } from "@/models/category";
-
-const seedCategories = [
-  "Laptops",
-  "Desktops",
-  "Tablets",
-  "Accessories",
-  "Networking",
-  "Audio",
-  "Monitors",
-  "Servers",
-];
-
-const highlightPool = [
-  "Battery health above 85%",
-  "Latest firmware applied",
-  "Fresh thermal paste and cleaning",
-  "SSD storage upgrade included",
-  "Ships with genuine charger",
-  "Undergoes 50-point QA testing",
-  "Comes with 6-month warranty",
-  "Ready for enterprise deployment",
-];
-
-function buildHighlights(index: number) {
-  const highlights: string[] = [];
-  for (let i = 0; i < 3; i += 1) {
-    const highlight = highlightPool[(index + i) % highlightPool.length];
-    highlights.push(highlight);
-  }
-  return highlights;
-}
 
 export async function POST() {
   try {
@@ -49,10 +18,8 @@ export async function POST() {
 
     await connectDB();
 
-    const batchId = Date.now();
-
     await Promise.all(
-      seedCategories.map((name) =>
+      dummySeedCategories.map((name) =>
         CategoryModel.updateOne(
           { name },
           {
@@ -65,35 +32,13 @@ export async function POST() {
       ),
     );
 
-    const dummyProducts = Array.from({ length: 50 }, (_, index) => {
-      const categoryName = seedCategories[index % seedCategories.length];
-      const condition = productConditions[index % productConditions.length];
-      const productNumber = index + 1;
-      const name = `${categoryName} Batch ${batchId}-${productNumber}`;
-      const price = Math.round(18000 + index * 550 + (index % 7) * 950);
-      const description = `${name} has been professionally refurbished with genuine parts, endurance tested, and prepared for instant deployment in business environments.`;
-      const imageUrl = `https://picsum.photos/seed/rajesh-${batchId}-${productNumber}/800/600`;
-      const highlights = buildHighlights(index);
-      const featured = index % 10 === 0;
-      const inStock = index % 6 !== 0;
-
-      return {
-        name,
-        category: categoryName,
-        description,
-        price,
-        condition,
-        imageUrl,
-        featured,
-        inStock,
-        highlights,
-      };
-    });
+    const batchId = Date.now();
+    const dummyProducts = createDummyProductBatch(50, batchId);
 
     await ProductModel.insertMany(dummyProducts, { ordered: false });
 
     return NextResponse.json(
-      { message: `Created ${dummyProducts.length} dummy products` },
+      { message: `Created ${dummyProducts.length} dummy products`, batchId },
       { status: 201 },
     );
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,21 +10,23 @@ export default async function HomePage() {
 
   return (
     <main className="flex min-h-screen flex-col bg-background">
-      <section className="relative overflow-hidden bg-gradient-to-b from-primary/15 via-background to-background py-20 sm:py-28">
+      <section className="relative overflow-hidden bg-gradient-to-b from-primary/15 via-background to-background py-16 sm:py-20 lg:py-28">
         <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,theme(colors.primary/20),transparent_55%)]" />
-        <div className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
-          <div className="space-y-8 text-left">
-            <span className="inline-flex items-center rounded-full bg-secondary px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-secondary-foreground">
+        <div className="absolute -left-32 top-20 -z-10 hidden h-72 w-72 rounded-full bg-primary/10 blur-3xl sm:block" />
+        <div className="absolute -right-32 bottom-10 -z-10 hidden h-80 w-80 rounded-full bg-secondary/30 blur-3xl lg:block" />
+        <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+          <div className="space-y-8 text-center lg:text-left">
+            <span className="inline-flex items-center justify-center rounded-full bg-secondary px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-secondary-foreground">
               Refurbished laptops & electronics
             </span>
             <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
               Premium devices, renewed with precision and ready to perform
             </h1>
-            <p className="max-w-xl text-lg text-muted-foreground">
+            <p className="mx-auto max-w-2xl text-lg text-muted-foreground lg:mx-0">
               Discover enterprise-grade laptops, tablets, and accessories that undergo a 50-point
               quality check, professional refurbishment, and ship with reliable warranty coverage.
             </p>
-            <div className="flex flex-wrap items-center gap-4">
+            <div className="flex flex-wrap items-center justify-center gap-4 lg:justify-start">
               <Button asChild size="lg">
                 <Link href="/products">Browse catalogue</Link>
               </Button>
@@ -71,9 +73,24 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="border-t border-border/60 bg-background py-16 sm:py-20">
-        <div className="mx-auto max-w-6xl px-6">
-          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      <section className="border-y border-border/60 bg-background/95 py-10">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-6 px-4 text-muted-foreground sm:px-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-foreground/60">Trusted by teams at</p>
+          <ul className="flex flex-wrap items-center gap-6 text-sm font-medium">
+            {[
+              "TechNova", "GreenGrid", "Orbit Labs", "InsightWorks", "RapidScale",
+            ].map((brand) => (
+              <li key={brand} className="rounded-full border border-border/60 px-4 py-1 text-foreground/80">
+                {brand}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="bg-background py-16 sm:py-20">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             <div className="rounded-2xl border border-border bg-secondary/40 p-8 shadow-sm">
               <h3 className="text-xl font-semibold text-foreground">Certified refurbishment</h3>
               <p className="mt-3 text-sm text-muted-foreground">
@@ -100,18 +117,18 @@ export default async function HomePage() {
       </section>
 
       <section className="bg-background py-16 sm:py-24" id="featured">
-        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6">
+        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:px-6">
           <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-end">
-            <div className="space-y-3">
+            <div className="space-y-3 text-center sm:text-left">
               <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
                 Ready-to-ship highlights
               </h2>
-              <p className="max-w-2xl text-muted-foreground">
+              <p className="mx-auto max-w-2xl text-muted-foreground sm:mx-0">
                 Hand-picked devices with fresh batteries, SSD upgrades, and professional calibration
                 to fit remote, hybrid, or on-site teams.
               </p>
             </div>
-            <Button asChild variant="secondary" size="lg">
+            <Button asChild variant="secondary" size="lg" className="mx-auto sm:mx-0">
               <Link href="/products">View all products</Link>
             </Button>
           </div>
@@ -132,7 +149,7 @@ export default async function HomePage() {
       </section>
 
       <section className="border-t border-border/60 bg-secondary/40 py-16 sm:py-24">
-        <div className="mx-auto max-w-4xl space-y-6 px-6 text-center">
+        <div className="mx-auto max-w-4xl space-y-6 px-4 text-center sm:px-6">
           <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
             Need a custom rollout or bulk refresh?
           </h2>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -14,14 +14,14 @@ export default async function ProductsPage() {
 
   return (
     <main className="flex min-h-screen flex-col bg-background">
-      <section className="relative overflow-hidden bg-gradient-to-b from-primary/10 via-background to-background py-20 sm:py-28">
+      <section className="relative overflow-hidden bg-gradient-to-b from-primary/10 via-background to-background py-16 sm:py-24">
         <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,theme(colors.primary/20),transparent_55%)]" />
-        <div className="mx-auto max-w-5xl space-y-8 px-6 text-center">
+        <div className="mx-auto max-w-5xl space-y-8 px-4 text-center sm:px-6">
           <span className="inline-flex items-center justify-center rounded-full bg-secondary px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-secondary-foreground">
             Available inventory
           </span>
           <h1 className="text-4xl font-semibold text-foreground sm:text-5xl">Your next device, renewed</h1>
-          <p className="text-lg text-muted-foreground">
+          <p className="mx-auto max-w-3xl text-lg text-muted-foreground">
             Each product listed here has been professionally refurbished, data-wiped, and certified for
             business-ready deployment. Filter by category to find the right fit for your team.
           </p>
@@ -37,10 +37,10 @@ export default async function ProductsPage() {
       </section>
 
       <section className="bg-background py-16 sm:py-24" id="catalogue">
-        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6">
+        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:px-6">
           <div className="space-y-3 text-center">
             <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">Certified catalogue</h2>
-            <p className="text-muted-foreground">
+            <p className="mx-auto max-w-3xl text-muted-foreground">
               Laptops, tablets, monitors, and accessories—all renewed, stress-tested, and backed by
               warranty.
             </p>

--- a/components/admin/categories-table.tsx
+++ b/components/admin/categories-table.tsx
@@ -67,6 +67,36 @@ export function CategoriesTable({ data }: CategoriesTableProps) {
           <p className="text-xs">Create categories from the add category page to populate this list.</p>
         </div>
       }
+      renderMobileRow={(category) => {
+        const formatted = category.lastUpdated
+          ? new Date(category.lastUpdated).toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" })
+          : "-";
+        return (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Folder className="h-5 w-5 text-muted-foreground" aria-hidden />
+                <span className="text-base font-semibold text-foreground">{category.name}</span>
+              </div>
+              <span className="inline-flex items-center rounded-full bg-muted px-3 py-1 text-xs font-semibold text-muted-foreground">
+                {category.productCount} products
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {category.description || "No description provided."}
+            </p>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Last updated: <span className="font-medium text-foreground">{formatted}</span>
+            </p>
+          </div>
+        );
+      }}
+      mobileEmptyState={
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">No categories found</p>
+          <p className="text-xs">Create categories from the add category page to populate this list.</p>
+        </div>
+      }
     />
   );
 }

--- a/components/admin/products-table.tsx
+++ b/components/admin/products-table.tsx
@@ -113,6 +113,48 @@ export function ProductsTable({ data, onEdit, onDelete }: ProductsTableProps) {
           <p className="text-xs">Try adjusting your filters or add a new product.</p>
         </div>
       }
+      renderMobileRow={(product) => (
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{product.category}</p>
+            <h3 className="text-lg font-semibold text-foreground">{product.name}</h3>
+            <p className="text-sm text-muted-foreground line-clamp-3">{product.description}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <span className="rounded-full bg-muted px-3 py-1 font-medium text-foreground">
+              {currencyFormatter.format(product.price)}
+            </span>
+            <span className="rounded-full bg-muted px-3 py-1 capitalize">{product.condition}</span>
+            <span className="rounded-full bg-muted px-3 py-1 font-medium">
+              {product.inStock ? "In stock" : "Out of stock"}
+            </span>
+            {product.featured ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                <BadgeCheck className="h-4 w-4" aria-hidden /> Featured
+              </span>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={() => onEdit(product)} className="flex-1 min-[420px]:flex-none">
+              Edit
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex-1 text-destructive hover:text-destructive min-[420px]:flex-none"
+              onClick={() => onDelete(product.id)}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+      )}
+      mobileEmptyState={
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">No products found</p>
+          <p className="text-xs">Try adjusting your filters or add a new product.</p>
+        </div>
+      }
     />
   );
 }

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -22,6 +22,8 @@ interface DataTableProps<TData, TValue> {
   searchKey?: string;
   emptyState?: React.ReactNode;
   className?: string;
+  renderMobileRow?: (item: TData) => React.ReactNode;
+  mobileEmptyState?: React.ReactNode;
 }
 
 export function DataTable<TData, TValue>({
@@ -31,6 +33,8 @@ export function DataTable<TData, TValue>({
   searchKey,
   emptyState,
   className,
+  renderMobileRow,
+  mobileEmptyState,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
@@ -52,6 +56,16 @@ export function DataTable<TData, TValue>({
   const searchColumn = searchKey ? table.getColumn(searchKey) : null;
   const searchValue = (searchColumn?.getFilterValue() as string) ?? "";
 
+  const mobileContent = renderMobileRow
+    ? table.getRowModel().rows.map((row) => (
+        <div key={row.id} className="rounded-xl border border-border/70 bg-background/95 p-4 shadow-sm">
+          {renderMobileRow(row.original)}
+        </div>
+      ))
+    : null;
+
+  const hasRows = table.getRowModel().rows?.length;
+
   return (
     <div className={cn("space-y-4", className)}>
       {searchColumn ? (
@@ -65,39 +79,52 @@ export function DataTable<TData, TValue>({
           />
         </div>
       ) : null}
-      <div className="overflow-hidden rounded-lg border">
-        <Table>
-          <TableHeader className="bg-muted/40">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className="hover:bg-muted/40">
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id} colSpan={header.colSpan}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(header.column.columnDef.header, header.getContext())}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id} data-state={row.getIsSelected() ? "selected" : undefined}>
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+      {renderMobileRow ? (
+        <div className="space-y-3 md:hidden">
+          {hasRows && mobileContent?.length ? (
+            mobileContent
+          ) : (
+            <div className="rounded-xl border border-dashed border-border/70 bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+              {mobileEmptyState ?? emptyState ?? "No records found"}
+            </div>
+          )}
+        </div>
+      ) : null}
+      <div className={cn(renderMobileRow ? "hidden md:block" : undefined)}>
+        <div className="overflow-x-auto rounded-lg border">
+          <Table className="min-w-full">
+            <TableHeader className="bg-muted/40">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id} className="hover:bg-muted/40">
+                  {headerGroup.headers.map((header) => (
+                    <TableHead key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
                   ))}
                 </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
-                  {emptyState ?? "No records found"}
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {hasRows ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow key={row.id} data-state={row.getIsSelected() ? "selected" : undefined}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                    {emptyState ?? "No records found"}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
       </div>
     </div>
   );

--- a/lib/dummy-products.ts
+++ b/lib/dummy-products.ts
@@ -1,0 +1,71 @@
+import { productConditions } from "@/lib/product-constants";
+
+export const dummySeedCategories = [
+  "Laptops",
+  "Desktops",
+  "Tablets",
+  "Accessories",
+  "Networking",
+  "Audio",
+  "Monitors",
+  "Servers",
+] as const;
+
+const highlightPool = [
+  "Battery health above 85%",
+  "Latest firmware applied",
+  "Fresh thermal paste and cleaning",
+  "SSD storage upgrade included",
+  "Ships with genuine charger",
+  "Undergoes 50-point QA testing",
+  "Comes with 6-month warranty",
+  "Ready for enterprise deployment",
+] as const;
+
+export interface DummyProductSeed {
+  name: string;
+  category: string;
+  description: string;
+  price: number;
+  condition: (typeof productConditions)[number];
+  imageUrl: string;
+  featured: boolean;
+  inStock: boolean;
+  highlights: string[];
+}
+
+function buildHighlights(index: number) {
+  const highlights: string[] = [];
+  for (let i = 0; i < 3; i += 1) {
+    const highlight = highlightPool[(index + i) % highlightPool.length];
+    highlights.push(highlight);
+  }
+  return highlights;
+}
+
+export function createDummyProductBatch(count = 50, batchId = Date.now()): DummyProductSeed[] {
+  return Array.from({ length: count }, (_, index) => {
+    const categoryName = dummySeedCategories[index % dummySeedCategories.length];
+    const condition = productConditions[index % productConditions.length];
+    const productNumber = index + 1;
+    const name = `${categoryName} Batch ${batchId}-${productNumber}`;
+    const price = Math.round(18000 + index * 550 + (index % 7) * 950);
+    const description = `${name} has been professionally refurbished with genuine parts, endurance tested, and prepared for instant deployment in business environments.`;
+    const imageUrl = `https://picsum.photos/seed/rajesh-${batchId}-${productNumber}/800/600`;
+    const highlights = buildHighlights(index);
+    const featured = index % 10 === 0;
+    const inStock = index % 6 !== 0;
+
+    return {
+      name,
+      category: categoryName,
+      description,
+      price,
+      condition,
+      imageUrl,
+      featured,
+      inStock,
+      highlights,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable dummy product batch generator and expose a POST endpoint at `/api/products/dummy`
- refresh landing and catalogue pages with better mobile spacing and trusted brands strip
- update admin data tables with responsive card views on small screens for categories and products

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d281af689c832b8215ec30cb943068