### PR TITLE
Add authenticated user menu to site navbar

### DIFF
--- a/components/auth/logout-button.tsx
+++ b/components/auth/logout-button.tsx
@@ -1,11 +1,27 @@
 "use client";
 
-import { useTransition } from "react";
+import { type ComponentProps, type ReactNode, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 
-export function LogoutButton() {
+interface LogoutButtonProps {
+  className?: string;
+  variant?: ComponentProps<typeof Button>["variant"];
+  size?: ComponentProps<typeof Button>["size"];
+  children?: ReactNode;
+  redirectTo?: string;
+  onLogout?: () => void;
+}
+
+export function LogoutButton({
+  className,
+  variant = "ghost",
+  size,
+  children,
+  redirectTo = "/",
+  onLogout,
+}: LogoutButtonProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -14,15 +30,16 @@ export function LogoutButton() {
       try {
         await fetch("/api/auth/logout", { method: "POST" });
       } finally {
-        router.replace("/login");
+        onLogout?.();
+        router.replace(redirectTo);
         router.refresh();
       }
     });
   }
 
   return (
-    <Button variant="ghost" onClick={logout} disabled={isPending}>
-      {isPending ? "Signing out..." : "Sign out"}
+    <Button variant={variant} size={size} className={className} onClick={logout} disabled={isPending}>
+      {children ?? (isPending ? "Signing out..." : "Sign out")}
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- add client-side session fetch in the site navbar to show the current user and hide auth links when signed in
- render a dropdown account menu with dashboard shortcuts and logout actions on desktop and mobile navigation
- make the reusable logout button support custom styling, callbacks, and redirect to the storefront after sign-out

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d36a189568832baad4ffcd158f5563