### PR TITLE
Add colour variants to products and update cart handling

### DIFF
--- a/app/(protected)/admin/orders/[orderId]/page.tsx
+++ b/app/(protected)/admin/orders/[orderId]/page.tsx
@@ -69,9 +69,15 @@ export default async function AdminOrderDetailPage({ params }: AdminOrderDetailP
               <h2 className="text-lg font-semibold text-foreground">Items</h2>
               <ul className="space-y-3 text-sm text-muted-foreground">
                 {order.items.map((item) => (
-                  <li key={item.productId} className="flex items-center justify-between gap-3">
+                  <li
+                    key={`${item.productId}-${item.color ?? "default"}`}
+                    className="flex items-center justify-between gap-3"
+                  >
                     <div>
                       <p className="font-medium text-foreground">{item.name}</p>
+                      {item.color ? (
+                        <p className="text-xs text-muted-foreground">Colour: {item.color}</p>
+                      ) : null}
                       <p className="text-xs">Qty {item.quantity}</p>
                     </div>
                     <span className="font-semibold text-foreground">{formatCurrency(item.total)}</span>

--- a/app/(protected)/dashboard/orders/[orderId]/page.tsx
+++ b/app/(protected)/dashboard/orders/[orderId]/page.tsx
@@ -73,11 +73,14 @@ export default async function OrderDetailPage({
               <ul className="space-y-3">
                 {order.items.map((item) => (
                   <li
-                    key={item.productId}
+                    key={`${item.productId}-${item.color ?? "default"}`}
                     className="flex items-center justify-between gap-3 text-sm text-muted-foreground"
                   >
                     <div>
                       <p className="font-medium text-foreground">{item.name}</p>
+                      {item.color ? (
+                        <p className="text-xs text-muted-foreground">Colour: {item.color}</p>
+                      ) : null}
                       <p className="text-xs">Qty {item.quantity}</p>
                     </div>
                     <span className="font-semibold text-foreground">

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -32,6 +32,9 @@ export async function POST(request: Request) {
       if (!product) {
         throw new Error(`Product not found: ${item.productId}`);
       }
+      const color = typeof item.color === "string" && item.color.trim().length > 0
+        ? item.color.trim()
+        : null;
       return {
         productId: product._id,
         name: product.name,
@@ -40,6 +43,7 @@ export async function POST(request: Request) {
         imageUrl: product.imageUrl ?? "",
         category: product.category ?? "",
         condition: product.condition ?? "",
+        color,
       };
     });
 
@@ -105,6 +109,7 @@ export async function POST(request: Request) {
         quantity: item.quantity,
         price: item.price,
         total: item.price * item.quantity,
+        color: item.color,
       })),
       shippingAddress: {
         line1: shippingAddress.line1,

--- a/app/api/products/[id]/route.ts
+++ b/app/api/products/[id]/route.ts
@@ -33,6 +33,25 @@ function sanitizeGallery(images: string[] | undefined) {
     });
 }
 
+function sanitizeColors(colors: string[] | undefined) {
+  if (!Array.isArray(colors)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return colors
+    .map((item) => item.trim())
+    .filter((item) => {
+      if (!item) {
+        return false;
+      }
+      if (seen.has(item.toLowerCase())) {
+        return false;
+      }
+      seen.add(item.toLowerCase());
+      return true;
+    });
+}
+
 function isValidId(id: string) {
   return mongoose.Types.ObjectId.isValid(id);
 }
@@ -64,6 +83,7 @@ export async function PUT(request: Request, context: { params: { id: string } })
     const highlights = sanitizeHighlights(payload.highlights);
     const galleryImages = sanitizeGallery(payload.galleryImages);
     const richDescription = sanitizeRichText(payload.richDescription?.trim() ?? "");
+    const colors = sanitizeColors(payload.colors);
 
     await connectDB();
     const updated = await ProductModel.findByIdAndUpdate(
@@ -81,6 +101,7 @@ export async function PUT(request: Request, context: { params: { id: string } })
           featured: payload.featured ?? false,
           inStock: payload.inStock ?? true,
           highlights,
+          colors,
         },
       },
       { new: true }

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -33,6 +33,25 @@ function sanitizeGallery(images: string[] | undefined) {
     });
 }
 
+function sanitizeColors(colors: string[] | undefined) {
+  if (!Array.isArray(colors)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return colors
+    .map((item) => item.trim())
+    .filter((item) => {
+      if (!item) {
+        return false;
+      }
+      if (seen.has(item.toLowerCase())) {
+        return false;
+      }
+      seen.add(item.toLowerCase());
+      return true;
+    });
+}
+
 export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
@@ -68,6 +87,7 @@ export async function POST(request: Request) {
     const highlights = sanitizeHighlights(payload.highlights);
     const galleryImages = sanitizeGallery(payload.galleryImages);
     const richDescription = sanitizeRichText(payload.richDescription?.trim() ?? "");
+    const colors = sanitizeColors(payload.colors);
 
     await connectDB();
     await ProductModel.create({
@@ -82,6 +102,7 @@ export async function POST(request: Request) {
       featured: payload.featured ?? false,
       inStock: payload.inStock ?? true,
       highlights,
+      colors,
     });
 
     return NextResponse.json({ message: "Product created" }, { status: 201 });

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -101,7 +101,10 @@ export default function CartPage() {
       <div className="mx-auto mt-10 grid w-full max-w-[90vw] gap-8 px-4 sm:px-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
         <div className="space-y-6">
           {items.map((item) => (
-            <CartLineItem key={item.productId} item={item} />
+            <CartLineItem
+              key={`${item.productId}-${item.color ?? "default"}`}
+              item={item}
+            />
           ))}
 
           <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-slate-200 bg-white/70 px-4 py-4 shadow-sm">

--- a/components/admin/products-table.tsx
+++ b/components/admin/products-table.tsx
@@ -13,6 +13,7 @@ interface ProductsTableProps {
   data: ProductSummary[];
   onEdit: (product: ProductSummary) => void;
   onDelete: (id: string) => void;
+  onDuplicate: (product: ProductSummary) => void;
 }
 
 const currencyFormatter = new Intl.NumberFormat("en-IN", {
@@ -21,7 +22,7 @@ const currencyFormatter = new Intl.NumberFormat("en-IN", {
   maximumFractionDigits: 0,
 });
 
-export function ProductsTable({ data, onEdit, onDelete }: ProductsTableProps) {
+export function ProductsTable({ data, onEdit, onDelete, onDuplicate }: ProductsTableProps) {
   const columns = React.useMemo<ColumnDef<ProductSummary>[]>(
     () => [
       {
@@ -84,6 +85,9 @@ export function ProductsTable({ data, onEdit, onDelete }: ProductsTableProps) {
             <Button variant="outline" size="sm" onClick={() => onEdit(row.original)}>
               Edit
             </Button>
+            <Button variant="outline" size="sm" onClick={() => onDuplicate(row.original)}>
+              Duplicate
+            </Button>
             <Button
               variant="ghost"
               size="sm"
@@ -97,7 +101,7 @@ export function ProductsTable({ data, onEdit, onDelete }: ProductsTableProps) {
         enableSorting: false,
       },
     ],
-    [onEdit, onDelete],
+    [onEdit, onDelete, onDuplicate],
   );
 
   return (
@@ -137,6 +141,14 @@ export function ProductsTable({ data, onEdit, onDelete }: ProductsTableProps) {
           <div className="flex flex-wrap gap-2">
             <Button variant="outline" size="sm" onClick={() => onEdit(product)} className="flex-1 min-[420px]:flex-none">
               Edit
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onDuplicate(product)}
+              className="flex-1 min-[420px]:flex-none"
+            >
+              Duplicate
             </Button>
             <Button
               variant="ghost"

--- a/components/cart/add-to-cart-button.tsx
+++ b/components/cart/add-to-cart-button.tsx
@@ -19,9 +19,19 @@ interface AddToCartButtonProps {
   };
   size?: "default" | "sm" | "lg";
   variant?: "default" | "secondary" | "outline";
+  selectedColor?: string | null;
+  requireColor?: boolean;
+  onMissingColor?: () => void;
 }
 
-export function AddToCartButton({ product, size = "default", variant = "default" }: AddToCartButtonProps) {
+export function AddToCartButton({
+  product,
+  size = "default",
+  variant = "default",
+  selectedColor,
+  requireColor = false,
+  onMissingColor,
+}: AddToCartButtonProps) {
   const addItem = useCartStore((state) => state.addItem);
   const [isPending, startTransition] = useTransition();
 
@@ -38,10 +48,18 @@ export function AddToCartButton({ product, size = "default", variant = "default"
           return;
         }
 
+        const normalizedColor = selectedColor?.trim() ?? "";
+        if (requireColor && !normalizedColor) {
+          toast.error("Please select a colour before adding to cart.");
+          onMissingColor?.();
+          return;
+        }
+
         startTransition(() => {
           addItem(
             {
               productId: product.id,
+              color: normalizedColor || null,
               name: product.name,
               price: product.price,
               imageUrl: product.imageUrl,
@@ -51,7 +69,9 @@ export function AddToCartButton({ product, size = "default", variant = "default"
             1
           );
           toast.success("Added to cart", {
-            description: `${product.name} was added to your cart`,
+            description: `${product.name}${
+              normalizedColor ? ` (${normalizedColor})` : ""
+            } was added to your cart`,
           });
         });
       }}

--- a/components/cart/cart-line-item.tsx
+++ b/components/cart/cart-line-item.tsx
@@ -53,6 +53,9 @@ export function CartLineItem({ item }: CartLineItemProps) {
           <h3 className="text-base font-semibold text-slate-900 line-clamp-2">
             {item.name}
           </h3>
+          {item.color ? (
+            <p className="text-xs font-medium text-slate-500">Colour: {item.color}</p>
+          ) : null}
           <p className="text-xs font-medium text-slate-600">
             Unit:{" "}
             <span className="font-semibold text-slate-900">
@@ -69,7 +72,7 @@ export function CartLineItem({ item }: CartLineItemProps) {
             variant="ghost"
             size="icon"
             className="size-7 rounded-full"
-            onClick={() => updateQuantity(item.productId, item.quantity - 1)}
+            onClick={() => updateQuantity(item.productId, item.color ?? null, item.quantity - 1)}
             disabled={item.quantity <= 1}
             aria-label={`Decrease quantity of ${item.name}`}
           >
@@ -79,11 +82,17 @@ export function CartLineItem({ item }: CartLineItemProps) {
             value={String(item.quantity)}
             onChange={(e) => {
               const parsed = Number.parseInt(e.target.value, 10);
-              if (!Number.isNaN(parsed)) updateQuantity(item.productId, parsed);
+              if (!Number.isNaN(parsed)) {
+                updateQuantity(item.productId, item.color ?? null, parsed);
+              }
             }}
             onBlur={(e) => {
               const parsed = Number.parseInt(e.target.value, 10);
-              updateQuantity(item.productId, Number.isNaN(parsed) ? 1 : parsed);
+              updateQuantity(
+                item.productId,
+                item.color ?? null,
+                Number.isNaN(parsed) ? 1 : parsed
+              );
             }}
             className="h-8 w-12 rounded-full border-0 bg-transparent text-center text-xs font-semibold"
             inputMode="numeric"
@@ -94,7 +103,7 @@ export function CartLineItem({ item }: CartLineItemProps) {
             variant="ghost"
             size="icon"
             className="size-7 rounded-full"
-            onClick={() => updateQuantity(item.productId, item.quantity + 1)}
+            onClick={() => updateQuantity(item.productId, item.color ?? null, item.quantity + 1)}
             disabled={item.quantity >= MAX_CART_QUANTITY}
             aria-label={`Increase quantity of ${item.name}`}
           >
@@ -115,7 +124,7 @@ export function CartLineItem({ item }: CartLineItemProps) {
           type="button"
           variant="ghost"
           className="h-8 px-2 text-xs text-slate-500 hover:text-red-600"
-          onClick={() => removeItem(item.productId)}
+          onClick={() => removeItem(item.productId, item.color ?? null)}
         >
           <Trash2 className="mr-1.5 h-3.5 w-3.5" />
           Remove

--- a/components/checkout/checkout-form.tsx
+++ b/components/checkout/checkout-form.tsx
@@ -227,6 +227,7 @@ export function CheckoutForm() {
           items: items.map((item) => ({
             productId: item.productId,
             quantity: item.quantity,
+            color: item.color ?? null,
           })),
         }),
       });
@@ -457,9 +458,15 @@ export function CheckoutForm() {
         <div className="space-y-4 divide-y divide-slate-200/80">
           <div className="space-y-3">
             {items.map((item) => (
-              <div key={item.productId} className="flex items-start justify-between gap-3">
+              <div
+                key={`${item.productId}-${item.color ?? "default"}`}
+                className="flex items-start justify-between gap-3"
+              >
                 <div>
                   <p className="text-sm font-medium text-slate-900">{item.name}</p>
+                  {item.color ? (
+                    <p className="text-xs text-slate-500">Colour: {item.color}</p>
+                  ) : null}
                   <p className="text-xs text-slate-500">
                     Qty {item.quantity} · {formatCurrency(item.price)} each
                   </p>

--- a/components/dashboard/user-orders-list.tsx
+++ b/components/dashboard/user-orders-list.tsx
@@ -120,10 +120,16 @@ export function UserOrdersList({ orders: initialOrders }: UserOrdersListProps) {
                 <h4 className="text-sm font-semibold text-foreground">Items</h4>
                 <ul className="space-y-2 text-sm text-muted-foreground">
                   {order.items.map((item) => (
-                    <li key={`${order.id}-${item.productId}`} className="flex items-center justify-between gap-3">
+                    <li
+                      key={`${order.id}-${item.productId}-${item.color ?? "default"}`}
+                      className="flex items-center justify-between gap-3"
+                    >
                       <span>
                         {item.name}
-                        <span className="text-xs text-muted-foreground"> × {item.quantity}</span>
+                        {item.color ? (
+                          <span className="ml-1 text-xs text-muted-foreground">({item.color})</span>
+                        ) : null}
+                        <span className="ml-1 text-xs text-muted-foreground">× {item.quantity}</span>
                       </span>
                       <span className="font-semibold text-foreground">
                         {formatCurrency(item.total)}

--- a/components/products/product-form.tsx
+++ b/components/products/product-form.tsx
@@ -49,6 +49,7 @@ type ProductFormValues = {
   featured: boolean;
   inStock: boolean;
   highlights: string;
+  colors: string;
   galleryImages: { url: string }[];
   richDescription: string;
 };
@@ -132,6 +133,11 @@ export function ProductForm({
           .max(800, "Highlights should be under 800 characters")
           .optional()
           .default(""),
+        colors: z
+          .string()
+          .max(400, "Colours should be under 400 characters")
+          .optional()
+          .default(""),
       }),
     []
   );
@@ -151,6 +157,7 @@ export function ProductForm({
       featured: product?.featured ?? false,
       inStock: product?.inStock ?? true,
       highlights: product?.highlights?.join("\n") ?? "",
+      colors: product?.colors?.join("\n") ?? "",
     },
   });
 
@@ -248,6 +255,28 @@ export function ProductForm({
       return;
     }
 
+    const rawColors = values.colors
+      .split(/[,\n]/)
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+
+    const uniqueColors = rawColors.filter(
+      (item, index) =>
+        rawColors.findIndex((candidate) => candidate.toLowerCase() === item.toLowerCase()) === index
+    );
+
+    if (values.colors.trim() && uniqueColors.length === 0) {
+      setServerError("Please enter at least one colour or leave the field empty.");
+      return;
+    }
+
+    if (uniqueColors.length > 12) {
+      setServerError("You can add up to 12 colours.");
+      return;
+    }
+
+    const colors = uniqueColors;
+
     const galleryImages = values.galleryImages
       .map((entry) => entry.url.trim())
       .filter((url, index, arr) => url.length > 0 && arr.indexOf(url) === index)
@@ -265,6 +294,7 @@ export function ProductForm({
       featured: values.featured,
       inStock: values.inStock,
       highlights,
+      colors,
     };
 
     try {
@@ -305,6 +335,7 @@ export function ProductForm({
           featured: false,
           inStock: true,
           highlights: "",
+          colors: "",
         });
       }
       if (redirectTo) {
@@ -615,6 +646,23 @@ export function ProductForm({
             {errors.richDescription ? (
               <p className="text-sm text-destructive" role="alert">
                 {errors.richDescription.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="colors">Colour options</Label>
+            <Textarea
+              id="colors"
+              placeholder="Enter one colour per line or separate with commas."
+              className="min-h-[80px]"
+              {...register("colors")}
+            />
+            <p className="text-xs text-muted-foreground">
+              Leave blank if the product has no colour variations.
+            </p>
+            {errors.colors ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errors.colors.message}
               </p>
             ) : null}
           </div>

--- a/components/products/product-manager.tsx
+++ b/components/products/product-manager.tsx
@@ -37,6 +37,44 @@ export function ProductManager({ products }: ProductManagerProps) {
     }
   }
 
+  async function handleDuplicate(product: ProductSummary) {
+    try {
+      const payload = {
+        name: `${product.name} (Copy)`,
+        category: product.category,
+        description: product.description,
+        price: product.price,
+        condition: product.condition,
+        imageUrl: product.imageUrl ?? "",
+        galleryImages: product.galleryImages ?? [],
+        richDescription: product.richDescription ?? "",
+        featured: product.featured,
+        inStock: product.inStock,
+        highlights: product.highlights ?? [],
+        colors: product.colors ?? [],
+      };
+
+      const response = await fetch("/api/products", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error ?? "Unable to duplicate product";
+        toast.error(typeof message === "string" ? message : "Unable to duplicate product");
+        return;
+      }
+
+      toast.success("Product duplicated");
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to duplicate product. Please try again.");
+    }
+  }
+
   return (
     <section className="space-y-8">
       <Card>
@@ -51,6 +89,7 @@ export function ProductManager({ products }: ProductManagerProps) {
             data={products}
             onEdit={(product) => router.push(`/admin/products/${product.id}/edit`)}
             onDelete={handleDelete}
+            onDuplicate={handleDuplicate}
           />
         </CardContent>
       </Card>

--- a/lib/checkout-validation.ts
+++ b/lib/checkout-validation.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 export const checkoutItemSchema = z.object({
   productId: z.string().min(1, "Product is required"),
   quantity: z.number().int().positive().max(10),
+  color: z
+    .string()
+    .trim()
+    .max(120, "Colour name is too long")
+    .optional()
+    .nullable(),
 });
 
 export const checkoutPayloadSchema = z.object({

--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -43,6 +43,7 @@ interface OrderEmailItem {
   quantity: number;
   price: number;
   total: number;
+  color?: string | null;
 }
 
 interface OrderEmailPayload {
@@ -78,7 +79,10 @@ function renderAddress(address: OrderEmailPayload["shippingAddress"]) {
 
 function renderItems(items: OrderEmailItem[]) {
   return items
-    .map((item) => `${item.name} (x${item.quantity}) — ${formatCurrency(item.total)}`)
+    .map(
+      (item) =>
+        `${item.name}${item.color ? ` (${item.color})` : ""} (x${item.quantity}) — ${formatCurrency(item.total)}`
+    )
     .join("\n");
 }
 
@@ -110,7 +114,7 @@ export async function sendOrderConfirmationEmail(payload: OrderEmailPayload) {
       ${payload.items
         .map(
           (item) =>
-            `<li><strong>${item.name}</strong> (x${item.quantity}) — ${formatCurrency(item.total)}</li>`
+            `<li><strong>${item.name}</strong>${item.color ? ` (${item.color})` : ""} (x${item.quantity}) — ${formatCurrency(item.total)}</li>`
         )
         .join("")}
     </ul>

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -10,6 +10,7 @@ export interface OrderItemSummary {
   imageUrl: string | null;
   category: string | null;
   condition: string | null;
+  color: string | null;
 }
 
 export interface OrderSummary {
@@ -53,6 +54,7 @@ function mapOrder(order: OrderDocument): OrderSummary {
         imageUrl: item.imageUrl || null,
         category: item.category || null,
         condition: item.condition || null,
+        color: item.color || null,
       }))
     : [];
 

--- a/lib/product-validation.ts
+++ b/lib/product-validation.ts
@@ -59,6 +59,11 @@ export const productPayloadSchema = z.object({
     )
     .optional()
     .default([]),
+  colors: z
+    .array(z.string().min(1, "Colour name cannot be empty"))
+    .max(12, "You can add up to 12 colours")
+    .optional()
+    .default([]),
 });
 
 export type ProductPayload = z.infer<typeof productPayloadSchema>;

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -16,6 +16,7 @@ export interface ProductSummary {
   richDescription: string | null;
   highlights: string[];
   featured: boolean;
+  colors: string[];
   inStock: boolean;
   createdAt: string;
   updatedAt: string;
@@ -60,6 +61,11 @@ function mapProduct(product: ProductDocument): ProductSummary {
       ? product.highlights.filter((item): item is string => Boolean(item && item.trim()))
       : [],
     featured: Boolean(product.featured),
+    colors: Array.isArray(product.colors)
+      ? product.colors
+          .map((item) => item.trim())
+          .filter((item, index, arr) => item.length > 0 && arr.indexOf(item) === index)
+      : [],
     inStock: Boolean(product.inStock),
     createdAt: product.createdAt ? product.createdAt.toISOString() : new Date().toISOString(),
     updatedAt: product.updatedAt ? product.updatedAt.toISOString() : new Date().toISOString(),

--- a/lib/stores/cart-store.ts
+++ b/lib/stores/cart-store.ts
@@ -8,6 +8,7 @@ export const MAX_CART_QUANTITY = 10;
 
 export interface CartItem {
   productId: string;
+  color: string | null;
   name: string;
   price: number;
   imageUrl: string | null;
@@ -20,8 +21,8 @@ interface CartState {
   items: CartItem[];
   hasHydrated: boolean;
   addItem: (item: Omit<CartItem, "quantity">, quantity?: number) => void;
-  removeItem: (productId: string) => void;
-  updateQuantity: (productId: string, quantity: number) => void;
+  removeItem: (productId: string, color?: string | null) => void;
+  updateQuantity: (productId: string, color: string | null, quantity: number) => void;
   clearCart: () => void;
   setHasHydrated: (state: boolean) => void;
 }
@@ -33,6 +34,14 @@ function clampQuantity(value: number) {
   return Math.min(MAX_CART_QUANTITY, Math.max(1, Math.trunc(value)));
 }
 
+function normalizeColor(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export const useCartStore = create<CartState>()(
   persist(
     (set, get) => ({
@@ -40,14 +49,20 @@ export const useCartStore = create<CartState>()(
       hasHydrated: false,
       addItem: (item, quantity = 1) => {
         const normalizedQuantity = clampQuantity(quantity);
-        const items = get().items;
-        const existing = items.find((entry) => entry.productId === item.productId);
+        const normalizedColor = normalizeColor(item.color);
+        const items = get()
+          .items
+          .map((entry) => ({ ...entry, color: normalizeColor(entry.color) }));
+        const existing = items.find(
+          (entry) => entry.productId === item.productId && entry.color === normalizedColor
+        );
         if (existing) {
           set({
             items: items.map((entry) =>
-              entry.productId === item.productId
+              entry.productId === item.productId && entry.color === normalizedColor
                 ? {
                     ...entry,
+                    color: normalizedColor,
                     quantity: clampQuantity(entry.quantity + normalizedQuantity),
                   }
                 : entry
@@ -62,26 +77,45 @@ export const useCartStore = create<CartState>()(
             ...items,
             {
               ...item,
+              color: normalizedColor,
               quantity: normalizedQuantity,
             },
           ],
           hasHydrated: true,
         });
       },
-      removeItem: (productId) => {
-        const items = get().items;
-        set({ items: items.filter((item) => item.productId !== productId), hasHydrated: true });
+      removeItem: (productId, color) => {
+        const normalizedColor = normalizeColor(color);
+        const items = get()
+          .items
+          .map((entry) => ({ ...entry, color: normalizeColor(entry.color) }));
+        set({
+          items: items.filter((item) => {
+            if (item.productId !== productId) {
+              return true;
+            }
+            return item.color !== normalizedColor;
+          }),
+          hasHydrated: true,
+        });
       },
-      updateQuantity: (productId, quantity) => {
+      updateQuantity: (productId, color, quantity) => {
         const normalized = clampQuantity(quantity);
-        const items = get().items;
-        const exists = items.some((item) => item.productId === productId);
+        const normalizedColor = normalizeColor(color);
+        const items = get()
+          .items
+          .map((entry) => ({ ...entry, color: normalizeColor(entry.color) }));
+        const exists = items.some(
+          (item) => item.productId === productId && item.color === normalizedColor
+        );
         if (!exists) {
           return;
         }
         set({
           items: items.map((item) =>
-            item.productId === productId ? { ...item, quantity: normalized } : item
+            item.productId === productId && item.color === normalizedColor
+              ? { ...item, quantity: normalized }
+              : item
           ),
           hasHydrated: true,
         });
@@ -100,15 +134,26 @@ export const useCartStore = create<CartState>()(
   )
 );
 
-export const selectCartItems = (state: CartState) => state.items;
+export const selectCartItems = (state: CartState) =>
+  state.items.map((item) => ({ ...item, color: normalizeColor(item.color) }));
 export const selectItemCount = (state: CartState) =>
   state.items.reduce((total, item) => total + item.quantity, 0);
 export const selectSubtotal = (state: CartState) =>
   state.items.reduce((total, item) => total + item.price * item.quantity, 0);
 export const selectQuantityById = (productId: string) => (state: CartState) => {
-  const entry = state.items.find((item) => item.productId === productId);
-  return entry?.quantity ?? 0;
+  return state.items
+    .filter((item) => item.productId === productId)
+    .reduce((total, item) => total + item.quantity, 0);
 };
+
+export const selectQuantityByVariant = (productId: string, color: string | null) =>
+  (state: CartState) => {
+    const normalizedColor = normalizeColor(color);
+    const entry = state.items.find(
+      (item) => item.productId === productId && normalizeColor(item.color) === normalizedColor
+    );
+    return entry?.quantity ?? 0;
+  };
 
 export function useCartHydration() {
   const hasHydrated = useCartStore((state) => state.hasHydrated);

--- a/models/order.ts
+++ b/models/order.ts
@@ -23,6 +23,7 @@ const orderItemSchema = new Schema(
     imageUrl: { type: String, default: "", trim: true },
     category: { type: String, default: "", trim: true },
     condition: { type: String, default: "", trim: true },
+    color: { type: String, default: "", trim: true },
   },
   { _id: false }
 );

--- a/models/product.ts
+++ b/models/product.ts
@@ -51,6 +51,10 @@ const ProductSchema = new Schema(
       type: Boolean,
       default: false,
     },
+    colors: {
+      type: [String],
+      default: [],
+    },
     inStock: {
       type: Boolean,
       default: true,


### PR DESCRIPTION
## Summary
- add colour options to the product schema, validation, admin tooling, and creation form
- update the product purchase UI and cart store so each colour variant is tracked as a distinct cart entry
- carry the selected colours through checkout and order displays so customers and admins see accurate variant details

## Testing
- npm test *(fails: cannot resolve @/app/api/products/seed/route referenced by tests/api/products-seed.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dba65255c8832bad939f19bcf27af2