### PR TITLE
feat: add admin analytics dashboard

### DIFF
--- a/app/(protected)/admin/dashboard/page.tsx
+++ b/app/(protected)/admin/dashboard/page.tsx
@@ -1,0 +1,14 @@
+import { Metadata } from "next";
+
+import { AdminDashboardContent } from "@/components/admin/dashboard/admin-dashboard-content";
+import { getAdminDashboardMetrics } from "@/lib/dashboard";
+
+export const metadata: Metadata = {
+  title: "Dashboard | Rajesh Control",
+};
+
+export default async function AdminDashboardPage() {
+  const metrics = await getAdminDashboardMetrics();
+
+  return <AdminDashboardContent metrics={metrics} />;
+}

--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function AdminPage() {
-  redirect("/admin/products");
+  redirect("/admin/dashboard");
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -6,6 +6,7 @@ import { getCurrentUser } from "@/lib/auth";
 import type { Role } from "@/models/user";
 
 const navLinks: Array<{ href: string; label: string; roles: Role[] }> = [
+  { href: "/admin/dashboard", label: "Dashboard", roles: ["admin", "superadmin"] },
   { href: "/dashboard/orders", label: "My orders", roles: ["user"] },
   { href: "/admin/orders", label: "Orders", roles: ["admin", "superadmin"] },
   { href: "/admin/transactions", label: "Transactions", roles: ["admin", "superadmin"] },

--- a/components/admin/dashboard/admin-dashboard-content.tsx
+++ b/components/admin/dashboard/admin-dashboard-content.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { AdminDashboardMetrics } from "@/lib/dashboard";
+import { getOrderStatusLabel } from "@/lib/order-status";
+
+interface AdminDashboardContentProps {
+  metrics: AdminDashboardMetrics;
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-IN", {
+  style: "currency",
+  currency: "INR",
+  maximumFractionDigits: 0,
+});
+
+const numberFormatter = new Intl.NumberFormat("en-IN", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-IN", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const chartColors = ["#2563eb", "#9333ea", "#0ea5e9", "#ec4899", "#f97316", "#22c55e"];
+
+function formatCurrency(value: number) {
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return currencyFormatter.format(safeValue);
+}
+
+function formatNumber(value: number) {
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return numberFormatter.format(safeValue);
+}
+
+export function AdminDashboardContent({ metrics }: AdminDashboardContentProps) {
+  const hasMonthlyData = metrics.monthlyOrders.some((entry) => entry.orderCount > 0 || entry.revenue > 0);
+  const hasPaymentData = metrics.paymentMethods.some((entry) => entry.revenue > 0);
+  const hasTransactionData = metrics.transactionsByStatus.some((entry) => entry.count > 0 || entry.amount > 0);
+  const transactionChartData = metrics.transactionsByStatus.map((entry) => ({
+    ...entry,
+    label: entry.status.charAt(0).toUpperCase() + entry.status.slice(1),
+  }));
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold text-foreground">Store dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Monitor orders, payments, and fulfillment activity to keep the storefront running smoothly.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Total revenue</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <p className="text-3xl font-semibold text-foreground">{formatCurrency(metrics.totals.totalRevenue)}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Gross sales generated across all orders.</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Total orders</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <p className="text-3xl font-semibold text-foreground">{formatNumber(metrics.totals.totalOrders)}</p>
+            <p className="mt-1 text-xs text-muted-foreground">All orders received through the storefront.</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Average order value</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <p className="text-3xl font-semibold text-foreground">{formatCurrency(metrics.totals.averageOrderValue)}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Revenue generated per order on average.</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Active fulfillment</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <div className="space-y-1">
+              <p className="text-3xl font-semibold text-foreground">{formatNumber(metrics.totals.processingOrders)}</p>
+              <p className="text-xs text-muted-foreground">Orders currently moving through processing.</p>
+            </div>
+            <div className="mt-3 flex items-center justify-between rounded-lg bg-muted/40 px-3 py-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Delivered</span>
+              <span className="text-sm font-semibold text-foreground">{formatNumber(metrics.totals.fulfilledOrders)}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-7">
+        <Card className="lg:col-span-4">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Orders &amp; revenue trend</CardTitle>
+          </CardHeader>
+          <CardContent className="h-[320px]">
+            {hasMonthlyData ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedOrdersChart data={metrics.monthlyOrders} />
+              </ResponsiveContainer>
+            ) : (
+              <EmptyChartState message="Orders will appear here once your store receives activity." />
+            )}
+          </CardContent>
+        </Card>
+        <Card className="lg:col-span-3">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Order status mix</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="h-[260px]">
+              {metrics.ordersByStatus.some((entry) => entry.count > 0) ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Tooltip formatter={(value: number) => formatNumber(value)} />
+                    <Legend verticalAlign="bottom" height={48} />
+                    <Pie
+                      data={metrics.ordersByStatus}
+                      dataKey="count"
+                      nameKey="label"
+                      innerRadius={60}
+                      outerRadius={90}
+                      paddingAngle={4}
+                    >
+                      {metrics.ordersByStatus.map((entry, index) => (
+                        <Cell key={entry.status} fill={chartColors[index % chartColors.length]} />
+                      ))}
+                    </Pie>
+                  </PieChart>
+                </ResponsiveContainer>
+              ) : (
+                <EmptyChartState message="Status distribution updates as orders progress through fulfillment." />
+              )}
+            </div>
+            <ul className="space-y-2">
+              {metrics.ordersByStatus.map((entry, index) => (
+                <li key={entry.status} className="flex items-center justify-between">
+                  <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: chartColors[index % chartColors.length] }}
+                      aria-hidden
+                    />
+                    {entry.label}
+                  </span>
+                  <span className="text-right">
+                    <span className="block text-sm font-semibold text-foreground">
+                      {formatNumber(entry.count)}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {formatCurrency(entry.revenue)}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-7">
+        <Card className="lg:col-span-4">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Payment methods</CardTitle>
+          </CardHeader>
+          <CardContent className="h-[320px]">
+            {hasPaymentData ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={metrics.paymentMethods}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => formatCurrency(value)} />
+                  <Tooltip formatter={(value: number) => [formatCurrency(value), "Revenue"]} />
+                  <Legend verticalAlign="top" height={32} />
+                  <Bar dataKey="revenue" name="Revenue" radius={[6, 6, 0, 0]} fill={chartColors[0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <EmptyChartState message="Collect payments to track gateway performance over time." />
+            )}
+          </CardContent>
+        </Card>
+        <Card className="lg:col-span-3">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Transaction health</CardTitle>
+          </CardHeader>
+          <CardContent className="h-[320px]">
+            {hasTransactionData ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={transactionChartData}>
+                  <CartesianGrid strokeDasharray="4 4" className="stroke-muted" />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => formatNumber(value)} />
+                  <Tooltip formatter={(value: number) => formatNumber(value)} />
+                  <Legend verticalAlign="top" height={32} />
+                  <Area
+                    type="monotone"
+                    dataKey="count"
+                    name="Transactions"
+                    stroke={chartColors[2]}
+                    fill={chartColors[2]}
+                    fillOpacity={0.2}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            ) : (
+              <EmptyChartState message="Payment activity will surface once transactions are recorded." />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold text-foreground">Recent orders</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          {metrics.recentOrders.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Order</TableHead>
+                  <TableHead>Customer</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead className="text-right">Placed</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {metrics.recentOrders.map((order) => (
+                  <TableRow key={order.id}>
+                    <TableCell className="font-medium">{order.orderNumber}</TableCell>
+                    <TableCell>{order.customerName}</TableCell>
+                    <TableCell>{getOrderStatusLabel(order.status)}</TableCell>
+                    <TableCell className="text-right font-semibold">{formatCurrency(order.total)}</TableCell>
+                    <TableCell className="text-right text-sm text-muted-foreground">
+                      {dateFormatter.format(new Date(order.createdAt))}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-sm text-muted-foreground">Orders will appear here once customers start purchasing.</p>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+function EmptyChartState({ message }: { message: string }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center rounded-lg border border-dashed border-border/60 bg-muted/40 px-6 text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+function ComposedOrdersChart({
+  data,
+}: {
+  data: AdminDashboardMetrics["monthlyOrders"];
+}) {
+  return (
+    <ComposedChart data={data}>
+      <CartesianGrid strokeDasharray="4 4" className="stroke-muted" />
+      <XAxis dataKey="month" tickLine={false} axisLine={false} />
+      <YAxis yAxisId="left" tickLine={false} axisLine={false} tickFormatter={(value) => formatNumber(value)} />
+      <YAxis
+        yAxisId="right"
+        orientation="right"
+        tickLine={false}
+        axisLine={false}
+        tickFormatter={(value) => formatCurrency(value)}
+      />
+      <Tooltip
+        formatter={(value: number, key) =>
+          key === "orderCount" ? formatNumber(value) : formatCurrency(value)
+        }
+      />
+      <Legend verticalAlign="top" height={32} />
+      <Bar yAxisId="left" dataKey="orderCount" name="Orders" fill={chartColors[0]} radius={[6, 6, 0, 0]} />
+      <Area
+        yAxisId="right"
+        type="monotone"
+        dataKey="revenue"
+        name="Revenue"
+        stroke={chartColors[1]}
+        fill={chartColors[1]}
+        fillOpacity={0.15}
+      />
+    </ComposedChart>
+  );
+}

--- a/components/admin/order-status-select.tsx
+++ b/components/admin/order-status-select.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -16,6 +16,10 @@ export function OrderStatusSelect({ orderId, status }: OrderStatusSelectProps) {
   const router = useRouter();
   const [currentStatus, setCurrentStatus] = useState<OrderStatusValue>(status);
   const [isUpdating, setIsUpdating] = useState(false);
+
+  useEffect(() => {
+    setCurrentStatus(status);
+  }, [status]);
 
   const handleChange = useCallback(
     async (nextStatus: OrderStatusValue) => {

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,257 @@
+import { ORDER_STATUSES, type OrderStatusValue } from "@/lib/order-status";
+import { connectDB } from "@/lib/db";
+import { OrderModel } from "@/models/order";
+import { TransactionModel } from "@/models/transaction";
+
+interface OrderStatusBreakdownEntry {
+  status: OrderStatusValue;
+  label: string;
+  count: number;
+  revenue: number;
+}
+
+interface MonthlyOrderEntry {
+  month: string;
+  orderCount: number;
+  revenue: number;
+}
+
+interface PaymentMethodEntry {
+  method: string;
+  label: string;
+  count: number;
+  revenue: number;
+}
+
+interface TransactionStatusEntry {
+  status: string;
+  count: number;
+  amount: number;
+}
+
+interface RecentOrderEntry {
+  id: string;
+  orderNumber: string;
+  customerName: string;
+  status: string;
+  total: number;
+  createdAt: string;
+}
+
+export interface AdminDashboardMetrics {
+  totals: {
+    totalRevenue: number;
+    totalOrders: number;
+    averageOrderValue: number;
+    processingOrders: number;
+    fulfilledOrders: number;
+  };
+  ordersByStatus: OrderStatusBreakdownEntry[];
+  monthlyOrders: MonthlyOrderEntry[];
+  paymentMethods: PaymentMethodEntry[];
+  transactionsByStatus: TransactionStatusEntry[];
+  recentOrders: RecentOrderEntry[];
+}
+
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  cod: "Cash on delivery",
+  razorpay: "Razorpay",
+};
+
+function getOrderNumberFromId(id: string) {
+  return `#${id.slice(-6).toUpperCase()}`;
+}
+
+export async function getAdminDashboardMetrics(): Promise<AdminDashboardMetrics> {
+  await connectDB();
+
+  const sixMonthsAgo = new Date();
+  sixMonthsAgo.setHours(0, 0, 0, 0);
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 5, 1);
+
+  const [
+    orderTotalsAggregation,
+    orderStatusAggregation,
+    monthlyOrdersAggregation,
+    paymentMethodAggregation,
+    transactionStatusAggregation,
+    recentOrdersDocs,
+  ] = await Promise.all([
+    OrderModel.aggregate<{
+      _id: null;
+      totalRevenue: number;
+      totalOrders: number;
+      averageOrderValue: number;
+      processingOrders: number;
+      fulfilledOrders: number;
+    }>([
+      {
+        $group: {
+          _id: null,
+          totalRevenue: { $sum: "$total" },
+          totalOrders: { $sum: 1 },
+          averageOrderValue: { $avg: "$total" },
+          processingOrders: {
+            $sum: {
+              $cond: [{ $in: ["$status", ["placed", "processing", "dispatched"]] }, 1, 0],
+            },
+          },
+          fulfilledOrders: {
+            $sum: {
+              $cond: [{ $in: ["$status", ["delivered"]] }, 1, 0],
+            },
+          },
+        },
+      },
+    ]),
+    OrderModel.aggregate<{
+      _id: string;
+      count: number;
+      revenue: number;
+    }>([
+      {
+        $group: {
+          _id: "$status",
+          count: { $sum: 1 },
+          revenue: { $sum: "$total" },
+        },
+      },
+    ]),
+    OrderModel.aggregate<{
+      _id: { year: number; month: number };
+      orderCount: number;
+      revenue: number;
+    }>([
+      { $match: { createdAt: { $gte: sixMonthsAgo } } },
+      {
+        $group: {
+          _id: { year: { $year: "$createdAt" }, month: { $month: "$createdAt" } },
+          orderCount: { $sum: 1 },
+          revenue: { $sum: "$total" },
+        },
+      },
+      { $sort: { "_id.year": 1, "_id.month": 1 } },
+    ]),
+    OrderModel.aggregate<{
+      _id: string;
+      count: number;
+      revenue: number;
+    }>([
+      {
+        $group: {
+          _id: "$paymentMethod",
+          count: { $sum: 1 },
+          revenue: { $sum: "$total" },
+        },
+      },
+    ]),
+    TransactionModel.aggregate<{
+      _id: string;
+      count: number;
+      amount: number;
+    }>([
+      { $match: { createdAt: { $gte: sixMonthsAgo } } },
+      {
+        $group: {
+          _id: "$status",
+          count: { $sum: 1 },
+          amount: { $sum: "$amount" },
+        },
+      },
+    ]),
+    OrderModel.find()
+      .sort({ createdAt: -1 })
+      .limit(6)
+      .select(["customerName", "total", "status", "createdAt"])
+      .lean<{
+        _id: { toString(): string };
+        customerName: string;
+        total: number;
+        status: string;
+        createdAt?: Date;
+      }>()
+      .exec(),
+  ]);
+
+  const totals = orderTotalsAggregation[0] ?? {
+    totalRevenue: 0,
+    totalOrders: 0,
+    averageOrderValue: 0,
+    processingOrders: 0,
+    fulfilledOrders: 0,
+  };
+
+  const ordersByStatus: OrderStatusBreakdownEntry[] = ORDER_STATUSES.map((status) => {
+    const match = orderStatusAggregation.find((entry) => entry._id === status.value);
+    return {
+      status: status.value,
+      label: status.label,
+      count: match?.count ?? 0,
+      revenue: match?.revenue ?? 0,
+    };
+  });
+
+  const monthFormatter = new Intl.DateTimeFormat("en-IN", { month: "short" });
+  const monthlyMap = new Map(
+    monthlyOrdersAggregation.map((entry) => [
+      `${entry._id.year}-${entry._id.month}`,
+      { orderCount: entry.orderCount, revenue: entry.revenue },
+    ])
+  );
+  const monthlyOrders: MonthlyOrderEntry[] = [];
+  const now = new Date();
+  now.setDate(1);
+  now.setHours(0, 0, 0, 0);
+  for (let index = 5; index >= 0; index -= 1) {
+    const date = new Date(now);
+    date.setMonth(now.getMonth() - index);
+    const mapKey = `${date.getFullYear()}-${date.getMonth() + 1}`;
+    const entry = monthlyMap.get(mapKey);
+    monthlyOrders.push({
+      month: `${monthFormatter.format(date)} ${date.getFullYear()}`,
+      orderCount: entry?.orderCount ?? 0,
+      revenue: entry?.revenue ?? 0,
+    });
+  }
+
+  const paymentMethods: PaymentMethodEntry[] = paymentMethodAggregation
+    .map((entry) => ({
+      method: entry._id,
+      label: PAYMENT_METHOD_LABELS[entry._id] ?? entry._id,
+      count: entry.count,
+      revenue: entry.revenue,
+    }))
+    .sort((a, b) => b.revenue - a.revenue);
+
+  const transactionsByStatus: TransactionStatusEntry[] = transactionStatusAggregation
+    .map((entry) => ({
+      status: entry._id,
+      count: entry.count,
+      amount: entry.amount,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const recentOrders: RecentOrderEntry[] = (recentOrdersDocs ?? []).map((order) => ({
+    id: order._id.toString(),
+    orderNumber: getOrderNumberFromId(order._id.toString()),
+    customerName: order.customerName,
+    status: order.status,
+    total: order.total ?? 0,
+    createdAt: order.createdAt?.toISOString?.() ?? new Date().toISOString(),
+  }));
+
+  return {
+    totals: {
+      totalRevenue: totals.totalRevenue ?? 0,
+      totalOrders: totals.totalOrders ?? 0,
+      averageOrderValue: totals.averageOrderValue ?? 0,
+      processingOrders: totals.processingOrders ?? 0,
+      fulfilledOrders: totals.fulfilledOrders ?? 0,
+    },
+    ordersByStatus,
+    monthlyOrders,
+    paymentMethods,
+    transactionsByStatus,
+    recentOrders,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.63.0",
+        "recharts": "^2.15.4",
         "sanitize-html": "^2.17.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
@@ -359,7 +360,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2959,6 +2959,69 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3458,8 +3521,128 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3497,6 +3680,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3560,6 +3749,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3802,6 +4001,12 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -3810,6 +4015,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-equals": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.2.tgz",
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/fdir": {
@@ -4099,6 +4313,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -4138,7 +4361,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -4453,6 +4675,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -4806,6 +5046,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -4904,6 +5153,23 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5031,6 +5297,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -5052,6 +5333,60 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -5378,6 +5713,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5593,6 +5934,28 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.63.0",
+    "recharts": "^2.15.4",
     "sanitize-html": "^2.17.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",


### PR DESCRIPTION
## Summary
- add server-side analytics helper that aggregates order, payment, and transaction metrics for admins
- build a rich admin dashboard page with KPI cards, bar/area/pie visualizations, and recent order listings
- expose the dashboard in navigation, redirect /admin to it, sync order status selector state, and add Recharts dependency for charting

## Testing
- npm run test *(fails: tests/api/products-seed.test.ts expects missing /app/api/products/seed/route import)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb84ff804832b98f5c12749d409c3